### PR TITLE
Add native install path without Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Copy to .env or .env.native and edit locally.
+# Do not commit real tokens or machine-specific secrets.
+
+SEARXNG_URL=http://localhost:8080
+HOST=127.0.0.1
+PORT=3939
+DATA_DIR=./data
+ADAPTERS_DIR=./adapters
+
+# Optional. If set, every endpoint except /health requires:
+# Authorization: Bearer <token>
+AGENT_SEARCH_TOKEN=

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on:
+  push:
+    branches: ["master", "main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest requests
+
+      - name: Run self-contained tests
+        run: pytest tests -q

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: Test
 
 on:
   push:
-    branches: ["master", "main"]
   pull_request:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 dist/
 build/
 .env
+.env.native
 .venv/
 venv/
 *.egg

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 build/
 .env
 .env.native
+.env.local
 .venv/
 venv/
 *.egg
@@ -16,6 +17,10 @@ data/*.db
 .mcpregistry_*
 
 # local-only secret-bearing files
+credentials/*
+!credentials/.gitignore
+!credentials/README.md
+!credentials/*.example
 searxng/settings.yml
 searxng/settings.tor.yml
 /torproxy/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ curl "http://localhost:3939/search?q=distributed+consensus+algorithms"
 
 Three commands. You now have a deduplicated, multi-engine search API running on `:3939`.
 
+If you enable auth, pass the token on all non-health endpoints:
+
+```bash
+export AGENT_SEARCH_TOKEN="change-me"
+curl -H "Authorization: Bearer $AGENT_SEARCH_TOKEN" \
+  "http://localhost:3939/search?q=distributed+consensus+algorithms"
+```
+
 Prefer not to use Docker for the API server?
 
 ```bash
@@ -23,6 +31,31 @@ cd agent-search
 ```
 
 Native mode requires Python 3.11+ and a reachable SearXNG instance with JSON output enabled. It stores AgentSearch state in `./data`. See [Native Install](docs/native-install.md).
+
+## Verify
+
+Run the self-contained test suite:
+
+```bash
+python -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt pytest requests
+pytest tests -q
+```
+
+Those tests mock SearXNG, so they do not require Docker or a running local service.
+
+Run the optional live localhost check:
+
+```bash
+AGENTSEARCH_INTEGRATION=1 pytest tests -q
+```
+
+If your local instance requires auth:
+
+```bash
+AGENT_SEARCH_TOKEN="change-me" AGENTSEARCH_INTEGRATION=1 pytest tests -q
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ curl "http://localhost:3939/search?q=distributed+consensus+algorithms"
 
 Three commands. You now have a deduplicated, multi-engine search API running on `:3939`.
 
+Prefer not to use Docker for the API server?
+
+```bash
+git clone https://github.com/brcrusoe72/agent-search.git
+cd agent-search
+./scripts/install-native.sh
+./scripts/run-native.sh
+```
+
+Native mode requires Python 3.11+ and a reachable SearXNG instance with JSON output enabled. It stores AgentSearch state in `./data`. See [Native Install](docs/native-install.md).
+
 ---
 
 ## What it does

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,0 +1,53 @@
+"""Command-line runner for native AgentSearch installs."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import uvicorn
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the AgentSearch API server.")
+    parser.add_argument("--host", default=os.getenv("HOST", "127.0.0.1"))
+    parser.add_argument("--port", type=int, default=int(os.getenv("PORT", "3939")))
+    parser.add_argument(
+        "--searxng-url",
+        default=os.getenv("SEARXNG_URL", "http://localhost:8080"),
+        help="Base URL of a running SearXNG instance.",
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=os.getenv("DATA_DIR", str(Path.cwd() / "data")),
+        help="Directory for AgentSearch SQLite cache/log state.",
+    )
+    parser.add_argument(
+        "--adapters-dir",
+        default=os.getenv("ADAPTERS_DIR", str(Path.cwd() / "adapters")),
+        help="Directory containing AgentSearch extraction adapters.",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.getenv("AGENT_SEARCH_TOKEN", ""),
+        help="Optional bearer token required for non-/health endpoints.",
+    )
+    parser.add_argument("--reload", action="store_true", help="Enable uvicorn reload for development.")
+    args = parser.parse_args()
+
+    data_dir = Path(args.data_dir).expanduser().resolve()
+    adapters_dir = Path(args.adapters_dir).expanduser().resolve()
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    os.environ["SEARXNG_URL"] = args.searxng_url.rstrip("/")
+    os.environ["DATA_DIR"] = str(data_dir)
+    os.environ["ADAPTERS_DIR"] = str(adapters_dir)
+    if args.token:
+        os.environ["AGENT_SEARCH_TOKEN"] = args.token
+
+    uvicorn.run("app.main:app", host=args.host, port=args.port, reload=args.reload)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/content_cache.py
+++ b/app/content_cache.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import os
 import sqlite3
 import time
 from pathlib import Path
@@ -42,9 +43,10 @@ STRATEGY_TTL = {
 class ContentCache:
     """SQLite-backed content cache with per-strategy TTLs."""
 
-    def __init__(self, db_path: str = "/app/data/content_cache.db"):
-        self.db_path = db_path
-        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    def __init__(self, db_path: str | None = None):
+        data_dir = Path(os.getenv("DATA_DIR", "data"))
+        self.db_path = db_path or str(data_dir / "content_cache.db")
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
         self._init_db()
         self._stats = {"hits": 0, "misses": 0, "sets": 0, "evictions": 0}
 

--- a/app/database.py
+++ b/app/database.py
@@ -2,6 +2,7 @@
 
 import sqlite3
 import asyncio
+import os
 import time
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -11,8 +12,9 @@ from contextlib import asynccontextmanager
 class QueryDatabase:
     """Simple SQLite database for tracking queries and engine performance."""
     
-    def __init__(self, db_path: str = "/app/data/query_log.db"):
-        self.db_path = db_path
+    def __init__(self, db_path: str | None = None):
+        data_dir = Path(os.getenv("DATA_DIR", "data"))
+        self.db_path = db_path or str(data_dir / "query_log.db")
         self._ensure_data_dir()
         self._init_db()
     

--- a/app/evolver.py
+++ b/app/evolver.py
@@ -26,15 +26,16 @@ import os
 
 logger = logging.getLogger("agentsearch.evolver")
 
-ADAPTERS_DIR = Path("/app/adapters")
-DYNAMIC_BLOCKLIST_PATH = Path(os.getenv("DATA_DIR", "/app/data")) / "blocked_domains.txt"
+ADAPTERS_DIR = Path(os.getenv("ADAPTERS_DIR", "adapters"))
+DYNAMIC_BLOCKLIST_PATH = Path(os.getenv("DATA_DIR", "data")) / "blocked_domains.txt"
 
 
 class Evolver:
     """Analyzes fetch patterns and recommends improvements."""
 
-    def __init__(self, db_path: str = "/app/data/content_cache.db"):
-        self.db_path = db_path
+    def __init__(self, db_path: str | None = None):
+        data_dir = Path(os.getenv("DATA_DIR", "data"))
+        self.db_path = db_path or str(data_dir / "content_cache.db")
 
     def _conn(self) -> sqlite3.Connection:
         conn = sqlite3.connect(self.db_path)

--- a/app/killchain.py
+++ b/app/killchain.py
@@ -51,7 +51,7 @@ from app.domain_trust import evaluate_trust, format_trust_tag, TrustResult
 # Configuration
 # ---------------------------------------------------------------------------
 
-ADAPTERS_DIR = Path(os.getenv("ADAPTERS_DIR", "/app/adapters"))
+ADAPTERS_DIR = Path(os.getenv("ADAPTERS_DIR", "adapters"))
 
 USER_AGENTS = [
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
@@ -98,7 +98,7 @@ BLOCKED_FETCH_DOMAINS = {
 }
 
 # Dynamic blocklist — loaded from file, written by evolver auto-apply
-DYNAMIC_BLOCKLIST_PATH = Path(os.getenv("DATA_DIR", "/app/data")) / "blocked_domains.txt"
+DYNAMIC_BLOCKLIST_PATH = Path(os.getenv("DATA_DIR", "data")) / "blocked_domains.txt"
 
 
 def _load_dynamic_blocklist() -> set[str]:

--- a/credentials/.gitignore
+++ b/credentials/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!README.md
+!*.example

--- a/credentials/README.md
+++ b/credentials/README.md
@@ -1,0 +1,15 @@
+# Local Credentials
+
+This directory is for local-only AgentSearch secrets. Everything here is ignored
+by git except this README, `.gitignore`, and `*.example` templates.
+
+Use this file for an AgentSearch bearer token:
+
+```text
+credentials/agent-search-token.txt
+```
+
+The file should contain only the token value, with no quotes or shell syntax.
+
+Do not store GitHub, PyPI, OpenAI, Claude, or other third-party credentials in
+this repository. Use each provider's CLI, keychain, or a dedicated secret manager.

--- a/credentials/agent-search-token.txt.example
+++ b/credentials/agent-search-token.txt.example
@@ -1,0 +1,1 @@
+replace-with-local-agent-search-token

--- a/docs/native-install.md
+++ b/docs/native-install.md
@@ -26,6 +26,9 @@ Edit `.env.native` if your SearXNG instance is not at `http://localhost:8080`, t
 ./scripts/run-native.sh
 ```
 
+`.env.native` is ignored by git. Keep local runtime settings there instead of in
+shell startup files like `~/.bashrc`.
+
 Verify:
 
 ```bash
@@ -116,6 +119,8 @@ If `AGENT_SEARCH_TOKEN` is set, all endpoints except `/health` require:
 curl -H "Authorization: Bearer $AGENT_SEARCH_TOKEN" \
   "http://localhost:3939/search?q=agent+search"
 ```
+
+For safer local token storage, see [Secret Handling](secrets.md).
 
 ## Notes
 

--- a/docs/native-install.md
+++ b/docs/native-install.md
@@ -1,0 +1,124 @@
+# Native Install
+
+AgentSearch can run without Docker as a normal Python service. Native mode runs the FastAPI wrapper, cache, extraction kill chain, adapters, and API server on the host.
+
+You still need a SearXNG instance somewhere. Docker Compose remains the easiest way to run both AgentSearch and SearXNG together. Native mode is for users who already run SearXNG, want to install SearXNG separately, or cannot use Docker for the AgentSearch API process.
+
+## Requirements
+
+- Python 3.11+
+- A reachable SearXNG instance with JSON search enabled
+- `ffmpeg` available on `PATH` for YouTube transcript extraction
+
+AgentSearch and SearXNG are separate services. The native installer below installs the AgentSearch API on the host. Point `SEARXNG_URL` at any SearXNG instance you control, whether it is running on the same machine, another host, or through a package/service manager.
+
+## Quick Start
+
+```bash
+git clone https://github.com/brcrusoe72/agent-search.git
+cd agent-search
+./scripts/install-native.sh
+```
+
+Edit `.env.native` if your SearXNG instance is not at `http://localhost:8080`, then start AgentSearch:
+
+```bash
+./scripts/run-native.sh
+```
+
+Verify:
+
+```bash
+curl http://localhost:3939/health
+curl "http://localhost:3939/search?q=distributed+consensus+algorithms"
+```
+
+## Manual Install
+
+```bash
+git clone https://github.com/brcrusoe72/agent-search.git
+cd agent-search
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -e .
+mkdir -p data
+
+agent-search \
+  --searxng-url http://localhost:8080 \
+  --data-dir ./data \
+  --adapters-dir ./adapters
+```
+
+## SearXNG Requirement
+
+Native AgentSearch does not start SearXNG for you. Before starting AgentSearch, make sure this works:
+
+```bash
+curl "http://localhost:8080/search?q=test&format=json"
+```
+
+If your SearXNG URL is different, use that URL in `.env.native`:
+
+```bash
+SEARXNG_URL=http://127.0.0.1:8080
+```
+
+Your SearXNG settings must allow JSON output. In SearXNG `settings.yml`, the `search.formats` list should include `json`:
+
+```yaml
+search:
+  formats:
+    - html
+    - json
+```
+
+How you install SearXNG is up to your host. Common options are a system package, an upstream SearXNG service install, or an already-running remote/private SearXNG instance. Docker Compose is only the bundled all-in-one path, not a requirement for AgentSearch native mode.
+
+## systemd Service
+
+For a long-running native install, create a service like this after running `./scripts/install-native.sh`:
+
+```ini
+[Unit]
+Description=AgentSearch API
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/agent-search
+EnvironmentFile=/opt/agent-search/.env.native
+ExecStart=/opt/agent-search/.venv/bin/agent-search
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Adjust `/opt/agent-search` to wherever you cloned the repository.
+
+## Configuration
+
+The native runner accepts CLI flags and equivalent environment variables:
+
+| Flag | Environment | Default | Purpose |
+|---|---|---|---|
+| `--host` | `HOST` | `127.0.0.1` | AgentSearch bind host |
+| `--port` | `PORT` | `3939` | AgentSearch bind port |
+| `--searxng-url` | `SEARXNG_URL` | `http://localhost:8080` | SearXNG base URL |
+| `--data-dir` | `DATA_DIR` | `./data` | SQLite cache, logs, dynamic blocklist |
+| `--adapters-dir` | `ADAPTERS_DIR` | `./adapters` | Extraction adapter modules |
+| `--token` | `AGENT_SEARCH_TOKEN` | empty | Optional bearer token for non-health endpoints |
+
+If `AGENT_SEARCH_TOKEN` is set, all endpoints except `/health` require:
+
+```bash
+curl -H "Authorization: Bearer $AGENT_SEARCH_TOKEN" \
+  "http://localhost:3939/search?q=agent+search"
+```
+
+## Notes
+
+- Native mode stores state under `DATA_DIR` instead of `/app/data`.
+- Docker mode still works unchanged because the container working directory is `/app`, so the default relative `data/` path maps to `/app/data`.
+- The private Tor stack still requires Docker Compose.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,55 @@
+# Secret Handling
+
+AgentSearch supports local credentials without putting secrets in chat prompts,
+shell startup files, commits, or public notes.
+
+## AgentSearch API Token
+
+If `AGENT_SEARCH_TOKEN` is set on the server, every endpoint except `/health`
+requires a bearer token.
+
+Recommended local options, in order:
+
+1. Export for the current shell only:
+
+   ```bash
+   export AGENT_SEARCH_TOKEN="replace-me"
+   ```
+
+2. Put runtime config in a gitignored `.env.native` file:
+
+   ```bash
+   cp .env.example .env.native
+   ```
+
+   Then edit `.env.native` locally.
+
+3. Put only the AgentSearch bearer token in:
+
+   ```text
+   credentials/agent-search-token.txt
+   ```
+
+4. For a user-wide SDK/MCP token, put only the token value in:
+
+   ```text
+   ~/.config/agent-search/token
+   ```
+
+## What Not To Do
+
+Do not put secrets in:
+
+- `~/.bashrc`, `~/.profile`, or other shell startup files
+- README files, notes, test fixtures, prompts, or chat messages
+- committed `.env` files
+- GitHub issue comments, PR comments, or Actions logs
+
+## Third-Party Tokens
+
+GitHub, PyPI, OpenAI, Anthropic/Claude, and similar provider credentials should
+use the provider's CLI login, keychain, or dedicated secret store. They should
+not be stored in this repository.
+
+If a token is pasted into chat, committed, or placed in a broadly readable file,
+treat it as compromised: revoke it and create a new one.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agentsearch-api"
+version = "2.0.0"
+description = "Self-hosted search and content extraction API for AI agents."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+dependencies = [
+    "fastapi==0.115.6",
+    "uvicorn[standard]==0.34.0",
+    "httpx[socks]==0.28.1",
+    "pydantic==2.10.4",
+    "beautifulsoup4==4.12.2",
+    "pdfplumber>=0.11.4,<0.12",
+    "lxml==5.1.0",
+    "requests[socks]==2.32.3",
+    "yt-dlp>=2025.3.31",
+    "python-whois>=0.9.4",
+]
+
+[project.scripts]
+agent-search = "app.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["app*"]

--- a/scripts/install-native.sh
+++ b/scripts/install-native.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON="${PYTHON:-python3}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+  echo "error: $PYTHON not found; install Python 3.11+ or set PYTHON=/path/to/python" >&2
+  exit 1
+fi
+
+if ! "$PYTHON" - <<'PY'
+import sys
+raise SystemExit(0 if sys.version_info >= (3, 11) else 1)
+PY
+then
+  echo "error: Python 3.11+ is required" >&2
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+"$PYTHON" -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e .
+mkdir -p data
+
+if [ ! -f .env.native ]; then
+  cat > .env.native <<'EOF'
+# AgentSearch native runtime config.
+# You still need a running SearXNG instance with JSON search enabled.
+SEARXNG_URL=http://localhost:8080
+HOST=127.0.0.1
+PORT=3939
+DATA_DIR=./data
+ADAPTERS_DIR=./adapters
+# AGENT_SEARCH_TOKEN=
+EOF
+fi
+
+echo "Native install complete."
+echo "Edit .env.native if needed, then run: ./scripts/run-native.sh"

--- a/scripts/run-native.sh
+++ b/scripts/run-native.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+if [ ! -d .venv ]; then
+  echo "error: .venv not found; run ./scripts/install-native.sh first" >&2
+  exit 1
+fi
+
+set -a
+if [ -f .env.native ]; then
+  . ./.env.native
+fi
+set +a
+
+. .venv/bin/activate
+exec agent-search \
+  --host "${HOST:-127.0.0.1}" \
+  --port "${PORT:-3939}" \
+  --searxng-url "${SEARXNG_URL:-http://localhost:8080}" \
+  --data-dir "${DATA_DIR:-./data}" \
+  --adapters-dir "${ADAPTERS_DIR:-./adapters}"

--- a/sdk/agentsearch/client.py
+++ b/sdk/agentsearch/client.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote_plus, urlencode, urljoin
@@ -48,19 +50,44 @@ class AgentSearch:
             print(r.title, r.url)
     """
 
-    def __init__(self, base_url: str = "http://localhost:3939", timeout: float = 30.0):
+    def __init__(self, base_url: str = "http://localhost:3939", timeout: float = 30.0, token: str | None = None):
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
+        self.token = token or self._load_token()
         self._session: Any = None
 
         # Try to use httpx for connection pooling
         try:
             import httpx  # type: ignore
 
-            self._session = httpx.Client(base_url=self.base_url, timeout=timeout)
+            self._session = httpx.Client(base_url=self.base_url, timeout=timeout, headers=self._headers())
             self._backend = "httpx"
         except ImportError:
             self._backend = "urllib"
+
+    def _load_token(self) -> str | None:
+        token = (os.environ.get("AGENT_SEARCH_TOKEN") or os.environ.get("AGENTSEARCH_TOKEN") or "").strip()
+        if token:
+            return token
+        for path in [
+            Path.cwd() / "credentials/agent-search-token.txt",
+            Path.home() / ".openclaw/workspace/credentials/agent-search-token.txt",
+            Path.home() / ".config/agent-search/token",
+        ]:
+            try:
+                if path.exists():
+                    token = path.read_text().strip()
+                    if token:
+                        return token
+            except Exception:
+                continue
+        return None
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
 
     def close(self) -> None:
         """Close the underlying HTTP session."""
@@ -101,7 +128,7 @@ class AgentSearch:
             filtered = {k: v for k, v in params.items() if v is not None}
             if filtered:
                 url += "?" + urlencode(filtered, doseq=True)
-        req = Request(url, headers={"Accept": "application/json"})
+        req = Request(url, headers=self._headers())
         try:
             with urlopen(req, timeout=self.timeout) as resp:
                 return json.loads(resp.read())
@@ -141,8 +168,8 @@ class AgentSearch:
         url = self.base_url + path
         data = json.dumps(body).encode()
         req = Request(url, data=data, headers={
+            **self._headers(),
             "Content-Type": "application/json",
-            "Accept": "application/json",
         })
         try:
             with urlopen(req, timeout=self.timeout) as resp:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,123 +1,144 @@
+"""AgentSearch API tests.
+
+Default tests are self-contained and do not require Docker, SearXNG, network
+access, or a running localhost service. Live integration tests can be enabled
+with:
+
+    AGENTSEARCH_INTEGRATION=1 pytest tests -v
 """
-AgentSearch API Tests
-Run: python -m pytest tests/ -v
-"""
-import subprocess
-import json
-import time
+from __future__ import annotations
+
+import os
+
 import pytest
+from fastapi.testclient import TestClient
 
-BASE_URL = "http://localhost:3939"
+from app import main
+from app.cache import Cache
+from app.database import QueryDatabase
 
 
-def curl_json(url: str) -> dict:
-    """Helper: curl a URL and return parsed JSON."""
-    result = subprocess.run(
-        ["curl", "-s", url],
-        capture_output=True, text=True, timeout=30
+class FakeResponse:
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            import httpx
+            raise httpx.HTTPStatusError("fake upstream error", request=None, response=None)
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class FakeSearxngClient:
+    async def get(self, url: str, params: dict | None = None, timeout: float | None = None) -> FakeResponse:
+        if url.endswith("/healthz"):
+            return FakeResponse({})
+        if url.endswith("/config"):
+            return FakeResponse({
+                "engines": [
+                    {"name": "duckduckgo", "shortcut": "ddg", "enabled": True, "categories": ["general"]},
+                    {"name": "brave", "shortcut": "br", "enabled": True, "categories": ["general"]},
+                ]
+            })
+        if url.endswith("/search"):
+            q = (params or {}).get("q", "query")
+            return FakeResponse({
+                "results": [
+                    {
+                        "title": f"{q} result one",
+                        "url": "https://example.com/one",
+                        "content": "First result snippet",
+                        "engines": ["duckduckgo"],
+                    },
+                    {
+                        "title": f"{q} result two",
+                        "url": "https://example.org/two",
+                        "content": "Second result snippet",
+                        "engines": ["brave"],
+                    },
+                ]
+            })
+        return FakeResponse({})
+
+
+@pytest.fixture(autouse=True)
+def isolated_app_state(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    monkeypatch.setattr(main, "_AUTH_TOKEN", "")
+    monkeypatch.setattr(main, "http_client", FakeSearxngClient())
+    monkeypatch.setattr(main, "content_cache", None)
+    monkeypatch.setattr(main, "evolver", None)
+    monkeypatch.setattr(main, "cache", Cache(ttl=3600))
+    monkeypatch.setattr(main, "query_db", QueryDatabase(str(tmp_path / "query_log.db")))
+    main._rate_store.clear()
+    main._global_timestamps.clear()
+    yield
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(main.app)
+
+
+def test_health_endpoint(client: TestClient) -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "healthy"
+    assert data["searxng_available"] is True
+    assert data["version"] == "2.0.0"
+
+
+def test_engines_endpoint(client: TestClient) -> None:
+    response = client.get("/engines")
+    assert response.status_code == 200
+    engines = response.json()
+    assert engines[0]["name"] == "duckduckgo"
+    assert engines[0]["enabled"] is True
+
+
+def test_search_returns_deduplicated_results(client: TestClient) -> None:
+    response = client.get("/search", params={"q": "manufacturing OEE", "count": 2})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["meta"]["query"] == "manufacturing OEE"
+    assert data["meta"]["total"] == 2
+    assert len(data["results"]) == 2
+    assert data["results"][0]["url"].startswith("https://")
+    assert "duckduckgo" in data["meta"]["engines_used"]
+
+
+def test_empty_query_returns_400(client: TestClient) -> None:
+    response = client.get("/search", params={"q": ""})
+    assert response.status_code == 400
+    assert "cannot be empty" in response.json()["detail"]
+
+
+def test_bearer_auth_when_enabled(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    monkeypatch.setattr(main, "_AUTH_TOKEN", "secret")
+
+    unauthorized = client.get("/search", params={"q": "python"})
+    assert unauthorized.status_code == 401
+
+    authorized = client.get(
+        "/search",
+        params={"q": "python"},
+        headers={"Authorization": "Bearer secret"},
     )
-    return json.loads(result.stdout)
+    assert authorized.status_code == 200
 
 
-class TestHealth:
-    def test_health_endpoint(self):
-        data = curl_json(f"{BASE_URL}/health")
-        assert data["status"] == "healthy"
-        assert data["searxng_available"] is True
-        assert "version" in data
+@pytest.mark.skipif(os.getenv("AGENTSEARCH_INTEGRATION") != "1", reason="Set AGENTSEARCH_INTEGRATION=1 for live localhost tests")
+def test_live_localhost_health() -> None:
+    import requests
 
-    def test_engines_endpoint(self):
-        data = curl_json(f"{BASE_URL}/engines")
-        assert isinstance(data, list)
-        assert len(data) > 0
-        # Check structure
-        engine = data[0]
-        assert "name" in engine
-        assert "enabled" in engine
+    headers = {}
+    token = os.getenv("AGENT_SEARCH_TOKEN") or os.getenv("AGENTSEARCH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
 
-
-class TestSearch:
-    def test_basic_search_returns_results(self):
-        data = curl_json(f"{BASE_URL}/search?q=Python+programming")
-        assert "results" in data
-        assert "meta" in data
-        assert len(data["results"]) > 0
-
-    def test_search_result_structure(self):
-        data = curl_json(f"{BASE_URL}/search?q=Python+pandas+tutorial")
-        result = data["results"][0]
-        assert "title" in result
-        assert "url" in result
-        assert "snippet" in result
-        assert "engines" in result
-        assert "score" in result
-        assert result["url"].startswith("http")
-
-    def test_search_count_parameter(self):
-        data = curl_json(f"{BASE_URL}/search?q=data+analysis&count=3")
-        assert len(data["results"]) <= 3
-
-    def test_search_meta_contains_query(self):
-        data = curl_json(f"{BASE_URL}/search?q=manufacturing+OEE")
-        assert data["meta"]["query"] == "manufacturing OEE"
-
-    def test_search_caching(self):
-        """Second identical query should be cached."""
-        q = f"cache_test_{int(time.time())}"
-        # First request
-        data1 = curl_json(f"{BASE_URL}/search?q={q}")
-        # Second request (same query)
-        data2 = curl_json(f"{BASE_URL}/search?q={q}")
-        assert data2["meta"]["cached"] is True
-
-    def test_search_deduplication(self):
-        """Results should not contain duplicate URLs."""
-        data = curl_json(f"{BASE_URL}/search?q=Python+data+science&count=20")
-        urls = [r["url"] for r in data["results"]]
-        assert len(urls) == len(set(urls)), "Duplicate URLs found in results"
-
-    def test_empty_query_handled(self):
-        """Empty query should return empty results or error gracefully."""
-        result = subprocess.run(
-            ["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", f"{BASE_URL}/search?q="],
-            capture_output=True, text=True, timeout=10
-        )
-        # Should return 400 or 422, or 200 with empty results — not 500
-        assert result.stdout in ("200", "400", "422")
-
-
-class TestJobSearch:
-    def test_job_search_returns_results(self):
-        data = curl_json(f"{BASE_URL}/search/jobs?q=MES+engineer+manufacturing")
-        assert "results" in data
-        assert len(data["results"]) > 0
-
-    def test_job_search_targets_job_boards(self):
-        """Job results should come from job-related sites."""
-        data = curl_json(f"{BASE_URL}/search/jobs?q=data+analyst+Python")
-        job_domains = ["indeed.com", "linkedin.com", "glassdoor.com", "ziprecruiter.com", "builtin.com"]
-        urls = [r["url"] for r in data["results"]]
-        # At least some results should be from job boards
-        job_board_hits = sum(1 for u in urls if any(d in u for d in job_domains))
-        assert job_board_hits > 0, f"No job board results found in: {urls[:5]}"
-
-    def test_job_search_result_structure(self):
-        data = curl_json(f"{BASE_URL}/search/jobs?q=manufacturing+engineer")
-        result = data["results"][0]
-        assert "title" in result
-        assert "url" in result
-
-
-class TestMultiEngine:
-    def test_results_from_multiple_engines(self):
-        """A broad query should return results from multiple search engines."""
-        data = curl_json(f"{BASE_URL}/search?q=Python+programming+tutorial&count=20")
-        all_engines = set()
-        for r in data["results"]:
-            all_engines.update(r.get("engines", []))
-        # Should have results from at least 2 different engines
-        assert len(all_engines) >= 2, f"Only got results from: {all_engines}"
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+    response = requests.get("http://localhost:3939/health", headers=headers, timeout=10)
+    assert response.status_code == 200
+    assert response.json()["status"] in {"healthy", "degraded"}

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -1,0 +1,36 @@
+"""SDK behavior tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sdk"))
+
+from agentsearch.client import AgentSearch  # noqa: E402
+
+
+def test_sdk_loads_token_from_environment(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_SEARCH_TOKEN", "env-token")
+
+    client = AgentSearch()
+
+    assert client.token == "env-token"
+    assert client._headers()["Authorization"] == "Bearer env-token"
+    client.close()
+
+
+def test_sdk_loads_token_from_local_credentials_file(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("AGENT_SEARCH_TOKEN", raising=False)
+    monkeypatch.delenv("AGENTSEARCH_TOKEN", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    token_file = tmp_path / "credentials" / "agent-search-token.txt"
+    token_file.parent.mkdir()
+    token_file.write_text("file-token\n")
+
+    client = AgentSearch()
+
+    assert client.token == "file-token"
+    assert client._headers()["Authorization"] == "Bearer file-token"
+    client.close()


### PR DESCRIPTION
## Summary

Adds a supported native install path for users who cannot or do not want to run the AgentSearch API server in Docker.

- Adds `pyproject.toml` with an `agent-search` console script.
- Adds `scripts/install-native.sh` and `scripts/run-native.sh` for Python venv based installs.
- Adds `docs/native-install.md` with SearXNG requirements, `.env.native` configuration, manual install steps, and a systemd example.
- Updates runtime paths so cache/database/adapters use `DATA_DIR` and `ADAPTERS_DIR` instead of hard-coded `/app/...` paths.
- Keeps Docker Compose behavior unchanged.

Closes #1.

## Validation

- `bash -n scripts/install-native.sh scripts/run-native.sh`
- `python3 -m compileall app tests`
- `python3 -m app.cli --help`
- Imported `app.main` with native `DATA_DIR`, `ADAPTERS_DIR`, and `SEARXNG_URL` environment settings.