### PR TITLE
Remove final unused SDK import

### DIFF
--- a/sdk/agentsearch/client.py
+++ b/sdk/agentsearch/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen


### PR DESCRIPTION
## Summary
- Remove the final unused `Union` import reported by CodeQL in the SDK client

## Verification
- `python3 -m pytest tests/test_sdk_client.py tests/test_api.py -q`
- `python3 -m compileall sdk app adapters -q`
- `git diff --check`