### PR TITLE
[codex] Add provider telemetry and direct search providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ AgentSearch delegates engine support to the connected SearXNG instance. The auth
 curl "http://localhost:3939/engines"
 ```
 
-The bundled `searxng/settings.example.yml` explicitly enables 25 engines: Google, Startpage, Brave, Bing, DuckDuckGo, Google Scholar, Semantic Scholar, arXiv, Crossref, OpenAlex, PubMed, Google News, Bing News, Yahoo News, Reuters, Wikinews, Wikipedia, Wikidata, Hugging Face, Reddit, Hacker News, Stack Overflow, GitHub, Docker Hub, and Lobsters.
+The bundled `searxng/settings.example.yml` explicitly enables 25 engines, including best-effort Google/Startpage/Yahoo entries plus Brave, Bing, DuckDuckGo, Google Scholar, Semantic Scholar, arXiv, Crossref, OpenAlex, PubMed, Bing News, Reuters, Wikinews, Wikipedia, Wikidata, Hugging Face, Reddit, Hacker News, Stack Overflow, GitHub, Docker Hub, and Lobsters.
 
 Run `./scripts/prepare-searxng.sh` to create ignored local runtime files at `searxng/settings.yml` and `searxng/settings.tor.yml` with generated SearXNG instance secrets. Do not commit those generated files.
 
 Because SearXNG is configured with `use_default_settings: true`, your live instance may expose additional enabled engines from the installed SearXNG catalog. Use the `engines=` query parameter to request specific engines, and use `/engines` to verify what is available in that deployment.
 
-Strategy modes can also use direct no-key providers for vertical search. These do not require paid search APIs: GitHub repository search, MDN search, Docker Hub search, arXiv, Crossref, OpenAlex, and Semantic Scholar are called directly when a mode selects them. SearXNG remains the broad-web provider for Google/Bing/Brave/DuckDuckGo-style engines.
+Strategy modes can also use direct no-key providers for vertical search. These do not require paid search APIs: GitHub repository search, MDN search, Docker Hub search, PyPI package metadata, Wikipedia, Wikidata, Hacker News, arXiv, Crossref, OpenAlex, and Semantic Scholar are called directly when a mode selects them. SearXNG remains the broad-web provider for Google/Bing/Brave/DuckDuckGo-style engines, but Google, Startpage, Yahoo, and Reddit are best-effort explicit sources rather than defaults because they are commonly blocked or empty.
 
 ## Why not just use SearXNG directly?
 
@@ -119,7 +119,7 @@ SearXNG finds pages. AgentSearch finds pages, reads them, scores them, deduplica
 | Endpoint | Method | What it does |
 |---|---|---|
 | `/search` | GET | Multi-engine web search with deduplication and scoring |
-| `/search/strategy` | GET | Named search modes: general, code, academic, news, private |
+| `/search/strategy` | GET | Named search modes: general, code, academic, news, private, reference, community |
 | `/search/deep` | GET | Server-side query expansion — runs variations in parallel, fuses results |
 | `/search/extract` | GET | Search + inline content extraction in one call |
 | `/search/jobs` | GET | Job search across LinkedIn, Indeed, Glassdoor, ZipRecruiter |
@@ -127,7 +127,7 @@ SearXNG finds pages. AgentSearch finds pages, reads them, scores them, deduplica
 | `/search/sources` | GET | Source discovery with institutional filtering |
 | `/search/sources/institutions` | GET | List source registry institutions |
 | `/search/stats` | GET | Query statistics and cache metrics |
-| `/news` | GET | Structured multi-source news (Google News, Bing News, Yahoo News) |
+| `/news` | GET | Structured multi-source news with reliable defaults and explicit engine overrides |
 
 ### Content extraction
 
@@ -164,6 +164,8 @@ Every request gets SSRF protection, prompt injection detection, paywall detectio
 |---|---|---|
 | `/health` | GET | Health check (API + SearXNG status) |
 | `/engines` | GET | List available search engines and their status |
+| `/providers/health` | GET | Summarize provider health from recorded live attempts |
+| `/providers/stats` | GET | Rolling provider/SearXNG attempt telemetry |
 
 ## Quick examples
 
@@ -180,11 +182,21 @@ Returns search results with extracted content inline — no second round-trip to
 ```bash
 curl "http://localhost:3939/search/strategy?q=fetch+api&mode=code&count=5"
 curl "http://localhost:3939/search?q=AI+regulation&mode=academic&count=5"
+curl "http://localhost:3939/search?q=Python&mode=reference&count=5"
 ```
 
-Modes validate or call only their declared sources instead of falling back silently: `general` tries Bing first and only uses the non-Bing SearXNG pack when needed; `code` uses direct GitHub, MDN, and Docker Hub providers; `academic` uses direct arXiv, Crossref, OpenAlex, and Semantic Scholar providers; `news` uses Reuters, Yahoo News, and Bing News through SearXNG; `private` avoids broad general web engines.
+Modes validate or call only their declared sources instead of falling back silently: `general` tries Bing first, then uses DuckDuckGo/Brave and direct reference/community providers only when more coverage is needed; `code` uses direct GitHub, MDN, Docker Hub, and PyPI providers; `academic` uses direct arXiv, Crossref, OpenAlex, and Semantic Scholar providers; `news` uses Reuters, Bing News, DuckDuckGo News, and Wikinews through SearXNG; `reference` uses direct Wikipedia and Wikidata providers; `community` uses direct Hacker News; `private` avoids broad general web engines.
 
 Each strategy response includes `meta.engine_attempts` with source/provider, query, raw result count, latency, and upstream errors so blocked or empty providers stay visible.
+
+Provider telemetry is available without running another probe:
+
+```bash
+curl "http://localhost:3939/providers/health"
+curl "http://localhost:3939/providers/stats"
+```
+
+Telemetry is in-memory and reflects live attempts since the API process started. It tracks attempts, successes, empty-result rate, errors, latency, last error, and last success per direct provider or SearXNG pack.
 
 ### Deep search (query expansion)
 

--- a/app/main.py
+++ b/app/main.py
@@ -31,7 +31,7 @@ import asyncio
 import secrets
 from collections import defaultdict
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import AsyncGenerator
 from urllib.parse import urlparse
 
@@ -47,7 +47,7 @@ from app.query_expansion import generate_query_variations
 from app.evolver import Evolver
 from app.source_tracer import trace_sources, get_institution_registry
 from app.database import query_db
-from app.search_providers import provider_by_name
+from app.search_providers import provider_by_name, providers_catalog
 from app.models import (
     AdaptReportRequest,
     AdaptStatsResponse,
@@ -243,6 +243,29 @@ class SearxngQueryResponse:
             self.unresponsive_engines = []
 
 
+@dataclass
+class ProviderAttemptStats:
+    """Rolling in-memory provider telemetry from real search attempts."""
+
+    source: str
+    name: str
+    attempts: int = 0
+    successes: int = 0
+    degraded: int = 0
+    errors: int = 0
+    empty: int = 0
+    total_raw_results: int = 0
+    latencies_ms: list[float] = field(default_factory=list)
+    last_status: str = "unknown"
+    last_error: str | None = None
+    last_attempt_at: float | None = None
+    last_success_at: float | None = None
+
+
+_provider_attempt_stats: dict[str, ProviderAttemptStats] = {}
+_PROVIDER_LATENCY_WINDOW = 200
+
+
 @dataclass(frozen=True)
 class EngineDescriptor:
     """Enabled SearXNG engine metadata used to validate engine requests."""
@@ -282,12 +305,16 @@ def _provider_pack(provider: str, label: str | None = None) -> SearchStrategyPac
 SEARCH_STRATEGY_MODES: dict[str, tuple[SearchStrategyPack, ...]] = {
     "general": (
         _searxng_pack("bing"),
-        _searxng_pack("duckduckgo", "brave", "google", "startpage"),
+        _searxng_pack("duckduckgo", "brave"),
+        _provider_pack("wikipedia", "wikipedia"),
+        _provider_pack("wikidata", "wikidata"),
+        _provider_pack("hackernews", "hackernews"),
     ),
     "code": (
         _provider_pack("github", "github"),
         _provider_pack("mdn", "mdn"),
         _provider_pack("docker_hub", "docker hub"),
+        _provider_pack("pypi", "pypi"),
     ),
     "academic": (
         _provider_pack("arxiv", "arxiv"),
@@ -296,15 +323,26 @@ SEARCH_STRATEGY_MODES: dict[str, tuple[SearchStrategyPack, ...]] = {
         _provider_pack("semantic_scholar", "semantic scholar"),
     ),
     "news": (
-        _searxng_pack("reuters", "yahoo news", "bing news"),
+        _searxng_pack("reuters", "bing news", "duckduckgo news", "wikinews"),
     ),
     "private": (
         _provider_pack("github", "github"),
         _provider_pack("mdn", "mdn"),
         _provider_pack("docker_hub", "docker hub"),
+        _provider_pack("pypi", "pypi"),
+        _provider_pack("wikipedia", "wikipedia"),
+        _provider_pack("wikidata", "wikidata"),
+        _provider_pack("hackernews", "hackernews"),
         _provider_pack("arxiv", "arxiv"),
         _provider_pack("crossref", "crossref"),
         _provider_pack("semantic_scholar", "semantic scholar"),
+    ),
+    "reference": (
+        _provider_pack("wikipedia", "wikipedia"),
+        _provider_pack("wikidata", "wikidata"),
+    ),
+    "community": (
+        _provider_pack("hackernews", "hackernews"),
     ),
 }
 
@@ -390,6 +428,137 @@ def _upstream_error_response(exc: Exception) -> SearxngQueryResponse:
         upstream_status="error",
         upstream_errors=[f"SearXNG error: {_safe_log_value(exc)}"],
     )
+
+
+def _record_searxng_attempt(name: str, upstream: SearxngQueryResponse) -> None:
+    _record_provider_attempt(
+        source="searxng",
+        name=name,
+        raw_results=len(upstream.results),
+        upstream_status=upstream.upstream_status,
+        response_time_ms=upstream.response_time_ms,
+        upstream_errors=upstream.upstream_errors,
+        unresponsive_engines=upstream.unresponsive_engines,
+    )
+
+
+def _record_searxng_error_attempt(name: str, exc: Exception, start: float) -> None:
+    upstream = _upstream_error_response(exc)
+    upstream.response_time_ms = round((time.time() - start) * 1000, 1)
+    _record_searxng_attempt(name, upstream)
+
+
+def _stats_key(source: str, name: str) -> str:
+    return f"{source}:{name}"
+
+
+def _format_ts(value: float | None) -> str | None:
+    if value is None:
+        return None
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(value))
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, round((len(ordered) - 1) * percentile)))
+    return round(ordered[index], 1)
+
+
+def _record_provider_attempt(
+    source: str,
+    name: str,
+    raw_results: int,
+    upstream_status: str,
+    response_time_ms: float,
+    upstream_errors: list[str] | None = None,
+    unresponsive_engines: list[str] | None = None,
+) -> None:
+    key = _stats_key(source, name)
+    stats = _provider_attempt_stats.get(key)
+    if stats is None:
+        stats = ProviderAttemptStats(source=source, name=name)
+        _provider_attempt_stats[key] = stats
+
+    now = time.time()
+    errors = upstream_errors or []
+    unresponsive = unresponsive_engines or []
+
+    stats.attempts += 1
+    stats.total_raw_results += max(raw_results, 0)
+    stats.last_status = upstream_status
+    stats.last_attempt_at = now
+    stats.latencies_ms.append(max(response_time_ms, 0.0))
+    if len(stats.latencies_ms) > _PROVIDER_LATENCY_WINDOW:
+        del stats.latencies_ms[: len(stats.latencies_ms) - _PROVIDER_LATENCY_WINDOW]
+
+    if raw_results > 0 and upstream_status == "ok":
+        stats.successes += 1
+        stats.last_success_at = now
+    if raw_results == 0:
+        stats.empty += 1
+    if upstream_status == "degraded":
+        stats.degraded += 1
+    if upstream_status == "error":
+        stats.errors += 1
+    if errors or unresponsive:
+        stats.last_error = "; ".join([*errors, *[f"unresponsive: {engine}" for engine in unresponsive]])[:500]
+    elif upstream_status == "ok":
+        stats.last_error = None
+
+
+def _provider_stats_row(stats: ProviderAttemptStats) -> dict:
+    attempts = max(stats.attempts, 1)
+    direct_engine_names = {
+        item["name"]: item["engine_name"]
+        for item in providers_catalog()
+    }
+    engine_name = direct_engine_names.get(stats.name, stats.name)
+    avg_latency = round(sum(stats.latencies_ms) / len(stats.latencies_ms), 1) if stats.latencies_ms else 0.0
+    success_rate = round(stats.successes / attempts, 3)
+    empty_rate = round(stats.empty / attempts, 3)
+    error_rate = round(stats.errors / attempts, 3)
+    if stats.attempts == 0:
+        health = "unknown"
+    elif stats.last_status == "error" or error_rate >= 0.5:
+        health = "error"
+    elif stats.last_status == "degraded" or empty_rate >= 0.5:
+        health = "degraded"
+    elif success_rate >= 0.5:
+        health = "healthy"
+    else:
+        health = "degraded"
+
+    return {
+        "source": stats.source,
+        "name": stats.name,
+        "engine_name": engine_name,
+        "health": health,
+        "attempts": stats.attempts,
+        "successes": stats.successes,
+        "degraded": stats.degraded,
+        "errors": stats.errors,
+        "empty": stats.empty,
+        "success_rate": success_rate,
+        "empty_rate": empty_rate,
+        "error_rate": error_rate,
+        "total_raw_results": stats.total_raw_results,
+        "avg_raw_results": round(stats.total_raw_results / attempts, 2),
+        "avg_latency_ms": avg_latency,
+        "p95_latency_ms": _percentile(stats.latencies_ms, 0.95),
+        "last_status": stats.last_status,
+        "last_error": stats.last_error,
+        "last_attempt_at": _format_ts(stats.last_attempt_at),
+        "last_success_at": _format_ts(stats.last_success_at),
+    }
+
+
+def _provider_stats_snapshot() -> list[dict]:
+    return [
+        _provider_stats_row(stats)
+        for _, stats in sorted(_provider_attempt_stats.items(), key=lambda item: item[0])
+    ]
 
 
 def _engine_key(value: str) -> str:
@@ -670,6 +839,16 @@ async def _search_strategy_impl(
             if engine_selection
             else [pack.label or pack.source]
         )
+        stats_name = engine_selection.value if engine_selection else (pack.provider or pack.label or pack.source)
+        _record_provider_attempt(
+            source=pack.source,
+            name=stats_name,
+            raw_results=len(upstream.results),
+            upstream_status=upstream.upstream_status,
+            response_time_ms=getattr(upstream, "response_time_ms", 0.0),
+            upstream_errors=upstream.upstream_errors,
+            unresponsive_engines=upstream.unresponsive_engines,
+        )
         engine_attempts.append({
             "mode": normalized_mode,
             "source": pack.source,
@@ -734,7 +913,7 @@ async def search(
     q: str = Query(..., description="Search query"),
     count: int = Query(10, ge=1, le=50, description="Number of results"),
     engines: str | None = Query(None, description="Comma-separated engine names"),
-    mode: str | None = Query(None, description="Named strategy: general, code, academic, news, or private"),
+    mode: str | None = Query(None, description="Named strategy: general, code, academic, news, private, reference, or community"),
     domain: str | None = Query(None, description="Filter results to this domain"),
     exclude_domains: str | None = Query(None, description="Comma-separated domains to exclude"),
     fetch: bool = Query(False, description="Fetch page content via kill chain"),
@@ -778,7 +957,10 @@ async def search(
     try:
         upstream = await _query_searxng(query_text, count * 2, resolved_engines or None)
     except httpx.HTTPError as e:
+        _record_searxng_error_attempt(resolved_engines or "default", e, start)
         raise HTTPException(status_code=502, detail=f"SearXNG error: {e}")
+
+    _record_searxng_attempt(resolved_engines or "default", upstream)
 
     results = deduplicate_with_scoring(upstream.results)
     results = _filter_search_results(results, domain=domain, exclude_domains=exclude_domains)[:count]
@@ -812,7 +994,7 @@ async def search(
 @app.get("/search/strategy", response_model=SearchResponse)
 async def search_strategy(
     q: str = Query(..., description="Search query"),
-    mode: str = Query("general", description="Named strategy: general, code, academic, news, or private"),
+    mode: str = Query("general", description="Named strategy: general, code, academic, news, private, reference, or community"),
     count: int = Query(10, ge=1, le=50, description="Number of results"),
     domain: str | None = Query(None, description="Filter results to this domain"),
     exclude_domains: str | None = Query(None, description="Comma-separated domains to exclude"),
@@ -834,7 +1016,7 @@ async def search_extract(
     q: str = Query(..., description="Search query"),
     count: int = Query(5, ge=1, le=20, description="Number of results"),
     engines: str | None = Query(None, description="Comma-separated engine names"),
-    mode: str | None = Query(None, description="Named strategy: general, code, academic, news, or private"),
+    mode: str | None = Query(None, description="Named strategy: general, code, academic, news, private, reference, or community"),
 ) -> SearchResponse:
     """Search and extract content from top results via kill chain."""
     return await search(q=q, count=count, engines=engines, mode=mode, domain=None, exclude_domains=None, fetch=True)
@@ -1189,7 +1371,7 @@ async def read_batch(body: BatchReadRequest) -> BatchReadResponse:
 # NEWS ENDPOINT
 # =========================================================================
 
-NEWS_ENGINES = "google news,bing news,duckduckgo news,yahoo news,brave.news,startpage news,qwant news,wikinews,reuters"
+NEWS_ENGINES = "reuters,bing news,duckduckgo news,wikinews"
 
 
 @app.get("/news", response_model=NewsResponse)
@@ -1210,7 +1392,10 @@ async def news(
     try:
         upstream = await _query_searxng(q, count * 3, engines=news_engines, categories="news")
     except httpx.HTTPError as e:
+        _record_searxng_error_attempt(news_engines, e, start)
         raise HTTPException(status_code=502, detail=f"SearXNG error: {e}")
+
+    _record_searxng_attempt(news_engines, upstream)
 
     # Deduplicate and build news results
     seen_urls: set[str] = set()
@@ -1456,6 +1641,69 @@ async def health() -> HealthResponse:
         **upstream_meta,
     )
     return response
+
+
+@app.get("/providers/stats")
+async def providers_stats() -> dict:
+    """Return rolling in-memory stats for provider and SearXNG attempts."""
+    providers = _provider_stats_snapshot()
+    return {
+        "total": len(providers),
+        "telemetry_scope": "in-memory live attempts since process start",
+        "known_direct_providers": providers_catalog(),
+        "providers": providers,
+    }
+
+
+@app.get("/providers/health")
+async def providers_health() -> dict:
+    """Summarize provider health from recorded live attempts."""
+    observed = _provider_stats_snapshot()
+    rows_by_key = {
+        _stats_key(row["source"], row["name"]): row
+        for row in observed
+    }
+
+    providers: list[dict] = []
+    for item in providers_catalog():
+        key = _stats_key("provider", item["name"])
+        providers.append(rows_by_key.pop(key, {
+            "source": "provider",
+            "name": item["name"],
+            "engine_name": item["engine_name"],
+            "health": "unknown",
+            "attempts": 0,
+            "successes": 0,
+            "degraded": 0,
+            "errors": 0,
+            "empty": 0,
+            "success_rate": 0.0,
+            "empty_rate": 0.0,
+            "error_rate": 0.0,
+            "last_status": "unknown",
+            "last_error": None,
+            "last_attempt_at": None,
+            "last_success_at": None,
+        }))
+    providers.extend(rows_by_key.values())
+
+    attempted = [row for row in providers if row.get("attempts", 0) > 0]
+    if not attempted:
+        status = "unknown"
+    elif any(row.get("health") == "error" for row in attempted):
+        status = "degraded"
+    elif any(row.get("health") == "degraded" for row in attempted):
+        status = "degraded"
+    else:
+        status = "healthy"
+
+    return {
+        "status": status,
+        "telemetry_scope": "in-memory live attempts since process start",
+        "attempted": len(attempted),
+        "total": len(providers),
+        "providers": providers,
+    }
 
 
 @app.get("/engines", response_model=list[EngineInfo])

--- a/app/search_providers.py
+++ b/app/search_providers.py
@@ -8,7 +8,7 @@ import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
 from html import unescape
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import quote, urljoin
 
 import httpx
 
@@ -81,6 +81,13 @@ def provider_by_name(name: str) -> SearchProvider:
         raise ValueError(f"Unknown provider: {name}") from exc
 
 
+def providers_catalog() -> list[dict[str, str]]:
+    return [
+        {"name": name, "engine_name": provider.engine_name}
+        for name, provider in sorted(PROVIDERS.items())
+    ]
+
+
 def _safe_text(value: object, limit: int = 1000) -> str:
     text = "" if value is None else str(value)
     text = re.sub(r"\s+", " ", text).strip()
@@ -106,6 +113,31 @@ def _json_items(data: Any, *path: str) -> list:
             return []
         current = current.get(key)
     return current if isinstance(current, list) else []
+
+
+def _html_attr(tag: str, attr: str) -> str:
+    match = re.search(rf"\b{re.escape(attr)}\s*=\s*([\"'])(.*?)\1", tag, flags=re.IGNORECASE | re.DOTALL)
+    return _safe_text(unescape(match.group(2)), limit=500) if match else ""
+
+
+def _html_anchors_with_class(html: str, class_name: str) -> list[tuple[str, str]]:
+    anchors: list[tuple[str, str]] = []
+    for match in re.finditer(r"(<a\b[^>]*>)(.*?)</a>", html, flags=re.IGNORECASE | re.DOTALL):
+        tag, body = match.groups()
+        classes = _html_attr(tag, "class").split()
+        if class_name in classes:
+            anchors.append((tag, body))
+    return anchors
+
+
+def _html_class_text(html: str, class_name: str) -> str:
+    class_pattern = re.escape(class_name)
+    match = re.search(
+        rf"<[^>]*\bclass\s*=\s*([\"'])[^\"']*\b{class_pattern}\b[^\"']*\1[^>]*>(.*?)</[^>]+>",
+        html,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    return _clean_snippet(match.group(2)) if match else ""
 
 
 def _abstract_from_openalex_index(index: object) -> str:
@@ -220,6 +252,193 @@ class DockerHubProvider(SearchProvider):
             if isinstance(pulls, int):
                 snippet = f"{snippet} Pulls: {pulls}".strip()
             results.append(self._result(repo_name, url, snippet))
+        return results
+
+
+class PyPIProvider(SearchProvider):
+    name = "pypi"
+    engine_name = "pypi"
+
+    async def _search(self, client: httpx.AsyncClient, query: str, count: int) -> list[dict]:
+        resp = await client.get(
+            "https://pypi.org/search/",
+            params={"q": query},
+            headers=DEFAULT_PROVIDER_HEADERS,
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+
+        results: list[dict] = []
+        for tag, block in _html_anchors_with_class(resp.text, "package-snippet"):
+            href = _html_attr(tag, "href")
+            if not href.startswith("/project/"):
+                continue
+            package_name = _html_class_text(block, "package-snippet__name")
+            if not package_name:
+                continue
+            version = _html_class_text(block, "package-snippet__version")
+            description = _html_class_text(block, "package-snippet__description")
+            snippet = description
+            if version:
+                snippet = f"{snippet} Version: {version}".strip()
+            results.append(
+                self._result(
+                    package_name,
+                    urljoin("https://pypi.org", href),
+                    snippet,
+                )
+            )
+            if len(results) >= count * 3:
+                break
+        return results
+
+
+class WikipediaProvider(SearchProvider):
+    name = "wikipedia"
+    engine_name = "wikipedia"
+
+    async def _search(self, client: httpx.AsyncClient, query: str, count: int) -> list[dict]:
+        resp = await client.get(
+            "https://en.wikipedia.org/w/api.php",
+            params={
+                "action": "query",
+                "list": "search",
+                "srsearch": query,
+                "srlimit": min(max(count * 3, 1), 50),
+                "format": "json",
+                "utf8": "1",
+                "origin": "*",
+            },
+            headers=DEFAULT_PROVIDER_HEADERS,
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        results: list[dict] = []
+        query_data = resp.json().get("query")
+        search_items = query_data.get("search") if isinstance(query_data, dict) else []
+        if not isinstance(search_items, list):
+            return []
+        for item in search_items[: count * 3]:
+            if not isinstance(item, dict):
+                continue
+            title = _safe_text(item.get("title"))
+            if not title:
+                continue
+            page_id = item.get("pageid")
+            url = f"https://en.wikipedia.org/?curid={page_id}" if page_id else f"https://en.wikipedia.org/wiki/{quote(title.replace(' ', '_'))}"
+            results.append(self._result(title, url, item.get("snippet") or ""))
+        return results
+
+
+class WikidataProvider(SearchProvider):
+    name = "wikidata"
+    engine_name = "wikidata"
+
+    async def _search(self, client: httpx.AsyncClient, query: str, count: int) -> list[dict]:
+        resp = await client.get(
+            "https://www.wikidata.org/w/api.php",
+            params={
+                "action": "wbsearchentities",
+                "search": query,
+                "language": "en",
+                "format": "json",
+                "limit": min(max(count * 3, 1), 50),
+                "origin": "*",
+            },
+            headers=DEFAULT_PROVIDER_HEADERS,
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        search_items = resp.json().get("search")
+        if not isinstance(search_items, list):
+            return []
+        results: list[dict] = []
+        for item in search_items[: count * 3]:
+            if not isinstance(item, dict):
+                continue
+            entity_id = _safe_text(item.get("id"))
+            label = item.get("label") or entity_id
+            url = _safe_text(item.get("concepturi")) or f"https://www.wikidata.org/wiki/{quote(entity_id)}"
+            if not entity_id or not url:
+                continue
+            aliases = item.get("aliases") if isinstance(item.get("aliases"), list) else []
+            alias_text = f" Aliases: {', '.join(str(alias) for alias in aliases[:5])}" if aliases else ""
+            results.append(self._result(label, url, f"{item.get('description') or ''}{alias_text}"))
+        return results
+
+
+class HackerNewsProvider(SearchProvider):
+    name = "hackernews"
+    engine_name = "hackernews"
+
+    async def _search(self, client: httpx.AsyncClient, query: str, count: int) -> list[dict]:
+        resp = await client.get(
+            "https://hn.algolia.com/api/v1/search",
+            params={
+                "query": query,
+                "tags": "story",
+                "hitsPerPage": min(max(count * 3, 1), 50),
+            },
+            headers=DEFAULT_PROVIDER_HEADERS,
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        results: list[dict] = []
+        for item in _json_items(resp.json(), "hits")[: count * 3]:
+            if not isinstance(item, dict):
+                continue
+            object_id = _safe_text(item.get("objectID"))
+            url = _safe_text(item.get("url")) or f"https://news.ycombinator.com/item?id={quote(object_id)}"
+            title = item.get("title") or item.get("story_title") or url
+            points = item.get("points")
+            comments = item.get("num_comments")
+            metrics = []
+            if isinstance(points, int):
+                metrics.append(f"Points: {points}")
+            if isinstance(comments, int):
+                metrics.append(f"Comments: {comments}")
+            results.append(self._result(title, url, " ".join(metrics)))
+        return results
+
+
+class RedditProvider(SearchProvider):
+    name = "reddit"
+    engine_name = "reddit"
+
+    async def _search(self, client: httpx.AsyncClient, query: str, count: int) -> list[dict]:
+        resp = await client.get(
+            "https://www.reddit.com/search.json",
+            params={
+                "q": query,
+                "limit": min(max(count * 3, 1), 50),
+                "sort": "relevance",
+                "t": "all",
+                "restrict_sr": "false",
+            },
+            headers={
+                **DEFAULT_PROVIDER_HEADERS,
+                "User-Agent": "AgentSearch/2.0 search provider (+https://github.com/brcrusoe72/agent-search)",
+            },
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        results: list[dict] = []
+        for child in _json_items(resp.json(), "data", "children")[: count * 3]:
+            if not isinstance(child, dict) or not isinstance(child.get("data"), dict):
+                continue
+            item = child["data"]
+            permalink = _safe_text(item.get("permalink"))
+            url = f"https://www.reddit.com{permalink}" if permalink.startswith("/") else _safe_text(item.get("url"))
+            if not url:
+                continue
+            subreddit = item.get("subreddit_name_prefixed") or item.get("subreddit") or ""
+            score = item.get("score")
+            snippet = item.get("selftext") or item.get("url") or ""
+            if subreddit:
+                snippet = f"{subreddit}. {snippet}".strip()
+            if isinstance(score, int):
+                snippet = f"{snippet} Score: {score}".strip()
+            results.append(self._result(item.get("title") or url, url, snippet))
         return results
 
 
@@ -341,6 +560,11 @@ PROVIDERS: dict[str, SearchProvider] = {
     "mdn": MDNProvider(),
     "github": GitHubProvider(),
     "docker_hub": DockerHubProvider(),
+    "pypi": PyPIProvider(),
+    "wikipedia": WikipediaProvider(),
+    "wikidata": WikidataProvider(),
+    "hackernews": HackerNewsProvider(),
+    "reddit": RedditProvider(),
     "arxiv": ArxivProvider(),
     "crossref": CrossrefProvider(),
     "openalex": OpenAlexProvider(),

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -28,8 +28,10 @@ Built on [AgentSearch](https://github.com/brcrusoe72/agent-search), which wraps 
 |------|-------------|
 | `health` | Check API, SearXNG, and live search health |
 | `engines` | List configured SearXNG engines |
+| `providers_health` | Summarize provider health from recorded live attempts |
+| `providers_stats` | Return rolling provider/SearXNG attempt telemetry |
 | `search` | SearXNG-backed web search with engine/mode, domain, exclusion, and extraction controls |
-| `search_strategy` | Named mode search: general, code, academic, news, private |
+| `search_strategy` | Named mode search: general, code, academic, news, private, reference, community |
 | `search_extract` | Search and extract readable content from top results |
 | `deep_search` | Multi-query fusion — generates 3-5 query variations and merges results |
 | `policy_search` | Policy/geopolitical search with source-library and domain-quality ranking |
@@ -74,7 +76,9 @@ Engine availability comes from the AgentSearch API and its connected SearXNG ins
 curl "http://localhost:3939/engines"
 ```
 
-The bundled AgentSearch SearXNG config explicitly enables 23 engines, and `use_default_settings: true` can expose additional engines from the installed SearXNG catalog. Avoid hard-coding a fixed engine count in clients.
+The bundled AgentSearch SearXNG config explicitly enables a focused engine set, and `use_default_settings: true` can expose additional engines from the installed SearXNG catalog. Avoid hard-coding a fixed engine count in clients.
+
+Strategy modes also include direct no-key providers for GitHub, MDN, Docker Hub, PyPI, Wikipedia, Wikidata, Hacker News, arXiv, Crossref, OpenAlex, and Semantic Scholar. Reddit is treated as best-effort because anonymous requests are often blocked. Use `providers_health` and `providers_stats` to inspect which providers are actually returning rows in the current process.
 
 ## Connect from Claude Desktop
 

--- a/mcp-server/agent_search_mcp/server.py
+++ b/mcp-server/agent_search_mcp/server.py
@@ -62,6 +62,16 @@ def make_server(base_url: str, token: str | None = None) -> Server:
                 inputSchema={"type": "object", "properties": {}},
             ),
             Tool(
+                name="providers_stats",
+                description="Return rolling provider and SearXNG attempt telemetry from AgentSearch.",
+                inputSchema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="providers_health",
+                description="Summarize provider health from recorded live AgentSearch attempts.",
+                inputSchema={"type": "object", "properties": {}},
+            ),
+            Tool(
                 name="search",
                 description="SearXNG-backed web search with optional engine, strategy mode, domain, exclusion, and fetch controls.",
                 inputSchema={
@@ -70,7 +80,7 @@ def make_server(base_url: str, token: str | None = None) -> Server:
                         "query": {"type": "string", "description": "Search query"},
                         "count": {"type": "integer", "description": "Number of results (default 10)", "default": 10},
                         "engines": {"type": "string", "description": "Comma-separated engine names"},
-                        "mode": {"type": "string", "description": "Named strategy: general, code, academic, news, or private"},
+                        "mode": {"type": "string", "description": "Named strategy: general, code, academic, news, private, reference, or community"},
                         "domain": {"type": "string", "description": "Restrict results to this domain"},
                         "exclude_domains": {"type": "string", "description": "Comma-separated domains to exclude"},
                         "fetch": {"type": "boolean", "description": "Also extract page content from top results", "default": False},
@@ -80,7 +90,7 @@ def make_server(base_url: str, token: str | None = None) -> Server:
             ),
             Tool(
                 name="search_strategy",
-                description="Search with a named engine strategy. Modes: general, code, academic, news, private.",
+                description="Search with a named engine strategy. Modes: general, code, academic, news, private, reference, community.",
                 inputSchema={
                     "type": "object",
                     "properties": {
@@ -103,7 +113,7 @@ def make_server(base_url: str, token: str | None = None) -> Server:
                         "query": {"type": "string", "description": "Search query"},
                         "count": {"type": "integer", "description": "Number of results (default 5)", "default": 5},
                         "engines": {"type": "string", "description": "Comma-separated engine names"},
-                        "mode": {"type": "string", "description": "Named strategy: general, code, academic, news, or private"},
+                        "mode": {"type": "string", "description": "Named strategy: general, code, academic, news, private, reference, or community"},
                     },
                     "required": ["query"],
                 },
@@ -218,6 +228,12 @@ def make_server(base_url: str, token: str | None = None) -> Server:
 
                 elif name == "engines":
                     r = await client.get("/engines")
+
+                elif name == "providers_stats":
+                    r = await client.get("/providers/stats")
+
+                elif name == "providers_health":
+                    r = await client.get("/providers/health")
 
                 elif name == "search":
                     params = {"q": arguments["query"], "count": arguments.get("count", 10)}

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -76,7 +76,7 @@ results = client.search("site reliability", domain="google.com")
 
 ### `client.search_strategy(query, *, mode="general", count=10, domain=None, exclude_domains=None, fetch=False)`
 
-Named strategy search. Modes are `general`, `code`, `academic`, `news`, and `private`. Code and academic modes use direct no-key providers where available, while broad web/news engines still run through the configured AgentSearch/SearXNG stack.
+Named strategy search. Modes are `general`, `code`, `academic`, `news`, `private`, `reference`, and `community`. Code, academic, reference, and community modes use direct no-key providers where available, while broad web/news engines still run through the configured AgentSearch/SearXNG stack. Reddit remains best-effort and is not selected by default because live anonymous requests are often blocked.
 
 ```python
 results = client.search_strategy("fetch api", mode="code", count=5)
@@ -148,7 +148,7 @@ print(f"Success: {results.successful}/{results.total}")
 
 ### `client.news(query, *, count=10, engines=None)`
 
-Search news across 9+ engines (Google News, Bing News, Reuters, Yahoo, Brave, etc.).
+Search news across the default reliable news pack (Reuters, Bing News, DuckDuckGo News, Wikinews) or explicitly selected SearXNG news engines.
 
 ```python
 articles = client.news("AI agents", count=10)
@@ -178,6 +178,25 @@ Check API health and SearXNG connectivity.
 ```python
 h = client.health()
 print(f"Status: {h.status}, Version: {h.version}")
+```
+
+### `client.providers_health()`
+
+Summarize provider health from recorded live attempts.
+
+```python
+health = client.providers_health()
+print(health["status"])
+```
+
+### `client.providers_stats()`
+
+Return rolling in-memory telemetry for direct providers and SearXNG packs.
+
+```python
+stats = client.providers_stats()
+for provider in stats["providers"]:
+    print(provider["source"], provider["name"], provider["success_rate"])
 ```
 
 ---

--- a/sdk/agentsearch/client.py
+++ b/sdk/agentsearch/client.py
@@ -282,7 +282,7 @@ class AgentSearch:
             query: Search query string.
             count: Number of results (1-50).
             engines: Comma-separated engine names.
-            mode: Named search strategy: general, code, academic, news, or private.
+            mode: Named search strategy: general, code, academic, news, private, reference, or community.
             domain: Filter results to this domain.
             exclude_domains: Comma-separated domains to exclude.
             fetch: If True, also extract page content via kill chain.
@@ -347,7 +347,7 @@ class AgentSearch:
             query: Search query string.
             count: Number of results (1-20).
             engines: Comma-separated engine names.
-            mode: Named search strategy: general, code, academic, news, or private.
+            mode: Named search strategy: general, code, academic, news, private, reference, or community.
 
         Returns:
             SearchResponse with results including extracted content.
@@ -541,3 +541,11 @@ class AgentSearch:
             unresponsive_engines=data.get("unresponsive_engines", []),
             version=data.get("version", ""),
         )
+
+    def providers_stats(self) -> Dict[str, Any]:
+        """Return rolling provider and SearXNG attempt telemetry."""
+        return self._get("/providers/stats")
+
+    def providers_health(self) -> Dict[str, Any]:
+        """Return provider health summarized from recorded live attempts."""
+        return self._get("/providers/health")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -138,6 +138,11 @@ class EngineAwareFakeSearxngClient:
         self.mdn_params: list[dict] = []
         self.github_params: list[dict] = []
         self.docker_hub_params: list[dict] = []
+        self.pypi_params: list[dict] = []
+        self.wikipedia_params: list[dict] = []
+        self.wikidata_params: list[dict] = []
+        self.hackernews_params: list[dict] = []
+        self.reddit_params: list[dict] = []
         self.arxiv_params: list[dict] = []
         self.crossref_params: list[dict] = []
         self.openalex_params: list[dict] = []
@@ -177,6 +182,70 @@ class EngineAwareFakeSearxngClient:
                         "pull_count": 1000000,
                     }
                 ]
+            })
+        if url.startswith("https://pypi.org/search/"):
+            self.pypi_params.append(dict(params or {}))
+            return FakeResponse({}, text="""
+                <a class="package-snippet" href="/project/fastapi/">
+                  <span class="package-snippet__name">fastapi</span>
+                  <span class="package-snippet__version">1.0.0</span>
+                  <p class="package-snippet__description">FastAPI framework</p>
+                </a>
+            """)
+        if url.startswith("https://en.wikipedia.org/w/api.php"):
+            self.wikipedia_params.append(dict(params or {}))
+            return FakeResponse({
+                "query": {
+                    "search": [
+                        {
+                            "title": "Python (programming language)",
+                            "pageid": 23862,
+                            "snippet": "Python is a programming language.",
+                        }
+                    ]
+                }
+            })
+        if url.startswith("https://www.wikidata.org/w/api.php"):
+            self.wikidata_params.append(dict(params or {}))
+            return FakeResponse({
+                "search": [
+                    {
+                        "id": "Q28865",
+                        "label": "Python",
+                        "description": "programming language",
+                        "concepturi": "https://www.wikidata.org/wiki/Q28865",
+                    }
+                ]
+            })
+        if url.startswith("https://hn.algolia.com/api/v1/search"):
+            self.hackernews_params.append(dict(params or {}))
+            return FakeResponse({
+                "hits": [
+                    {
+                        "title": "Python async discussion",
+                        "url": "https://news.ycombinator.com/item?id=1",
+                        "objectID": "1",
+                        "points": 100,
+                        "num_comments": 42,
+                    }
+                ]
+            })
+        if url.startswith("https://www.reddit.com/search.json"):
+            self.reddit_params.append(dict(params or {}))
+            return FakeResponse({
+                "data": {
+                    "children": [
+                        {
+                            "data": {
+                                "title": "Python discussion",
+                                "permalink": "/r/Python/comments/1/example/",
+                                "subreddit_name_prefixed": "r/Python",
+                                "selftext": "Python community discussion",
+                                "score": 123,
+                            }
+                        }
+                    ]
+                }
             })
         if url.startswith("https://export.arxiv.org/api/query"):
             self.arxiv_params.append(dict(params or {}))
@@ -241,6 +310,8 @@ class EngineAwareFakeSearxngClient:
                     {"name": "reuters", "shortcut": "reu", "enabled": True, "categories": ["news"]},
                     {"name": "yahoo news", "shortcut": "yn", "enabled": True, "categories": ["news"]},
                     {"name": "bing news", "shortcut": "bn", "enabled": True, "categories": ["news"]},
+                    {"name": "duckduckgo news", "shortcut": "ddn", "enabled": True, "categories": ["news"]},
+                    {"name": "wikinews", "shortcut": "wn", "enabled": True, "categories": ["news"]},
                     {"name": "bing", "shortcut": "b", "enabled": True, "categories": ["general", "web"]},
                     {"name": "disabled", "shortcut": "off", "enabled": False, "categories": ["general"]},
                 ]
@@ -295,6 +366,13 @@ class EngineAwareFakeSearxngClient:
         return FakeResponse({})
 
 
+class RaisingSearchFakeSearxngClient(EngineAwareFakeSearxngClient):
+    async def get(self, url: str, params: dict | None = None, timeout: float | None = None, **kwargs) -> FakeResponse:
+        if url.endswith("/search"):
+            raise httpx.ReadTimeout("fake timeout")
+        return await super().get(url, params=params, timeout=timeout, **kwargs)
+
+
 class AppClient:
     """Small sync wrapper around ASGITransport for self-contained API tests."""
 
@@ -318,6 +396,7 @@ def isolated_app_state(monkeypatch: pytest.MonkeyPatch, tmp_path):
     monkeypatch.setattr(main, "query_db", QueryDatabase(str(tmp_path / "query_log.db")))
     main._rate_store.clear()
     main._global_timestamps.clear()
+    main._provider_attempt_stats.clear()
     yield
 
 
@@ -488,14 +567,14 @@ def test_search_strategy_general_falls_back_to_non_bing_pack(monkeypatch: pytest
     data = response.json()
     assert [params["engines"] for params in fake.search_params] == [
         "bing",
-        "duckduckgo,brave,google,startpage",
+        "duckduckgo,brave",
     ]
     assert data["meta"]["fallback_reason"] == "no_results"
-    assert data["meta"]["engine_attempts"][1]["engines"] == ["duckduckgo", "brave", "google", "startpage"]
+    assert data["meta"]["engine_attempts"][1]["engines"] == ["duckduckgo", "brave"]
     assert "bing" not in data["meta"]["engines_used"]
 
 
-def test_search_strategy_code_uses_github_mdn_and_docker_hub(monkeypatch: pytest.MonkeyPatch, client: AppClient) -> None:
+def test_search_strategy_code_uses_direct_code_providers(monkeypatch: pytest.MonkeyPatch, client: AppClient) -> None:
     fake = EngineAwareFakeSearxngClient()
     monkeypatch.setattr(main, "http_client", fake)
 
@@ -507,14 +586,50 @@ def test_search_strategy_code_uses_github_mdn_and_docker_hub(monkeypatch: pytest
     assert fake.github_params[0]["q"] == "fetch api"
     assert fake.mdn_params == [{"q": "fetch api", "locale": "en-US"}]
     assert fake.docker_hub_params[0]["query"] == "fetch api"
+    assert fake.pypi_params == [{"q": "fetch api"}]
     assert [attempt["engines"] for attempt in data["meta"]["engine_attempts"]] == [
         ["github"],
         ["mdn"],
         ["docker hub"],
+        ["pypi"],
     ]
-    assert {"github", "mdn", "docker hub"}.issubset(set(data["meta"]["engines_used"]))
+    assert {"github", "mdn", "docker hub", "pypi"}.issubset(set(data["meta"]["engines_used"]))
     assert data["results"][0]["url"] == "https://github.com/python/cpython"
     assert data["meta"]["fallback_reason"] is None
+
+
+def test_search_strategy_reference_uses_wikipedia_and_wikidata(monkeypatch: pytest.MonkeyPatch, client: AppClient) -> None:
+    fake = EngineAwareFakeSearxngClient()
+    monkeypatch.setattr(main, "http_client", fake)
+
+    response = client.get("/search/strategy", params={"q": "Python", "count": 10, "mode": "reference"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert fake.search_params == []
+    assert fake.wikipedia_params[0]["srsearch"] == "Python"
+    assert fake.wikidata_params[0]["search"] == "Python"
+    assert [attempt["engines"] for attempt in data["meta"]["engine_attempts"]] == [
+        ["wikipedia"],
+        ["wikidata"],
+    ]
+    assert {"wikipedia", "wikidata"}.issubset(set(data["meta"]["engines_used"]))
+
+
+def test_search_strategy_community_uses_hackernews(monkeypatch: pytest.MonkeyPatch, client: AppClient) -> None:
+    fake = EngineAwareFakeSearxngClient()
+    monkeypatch.setattr(main, "http_client", fake)
+
+    response = client.get("/search/strategy", params={"q": "python async", "count": 10, "mode": "community"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert fake.search_params == []
+    assert fake.hackernews_params[0]["query"] == "python async"
+    assert [attempt["engines"] for attempt in data["meta"]["engine_attempts"]] == [
+        ["hackernews"],
+    ]
+    assert "hackernews" in data["meta"]["engines_used"]
 
 
 def test_search_strategy_academic_uses_direct_providers(monkeypatch: pytest.MonkeyPatch, client: AppClient) -> None:
@@ -546,11 +661,75 @@ def test_search_strategy_news_uses_requested_news_pack(monkeypatch: pytest.Monke
     response = client.get("/search", params={"q": "semiconductors", "count": 3, "mode": "news"})
 
     assert response.status_code == 200
-    assert fake.search_params[0]["engines"] == "reuters,yahoo news,bing news"
+    assert fake.search_params[0]["engines"] == "reuters,bing news,duckduckgo news,wikinews"
     assert "categories" not in fake.search_params[0]
     meta = response.json()["meta"]
     assert meta["mode"] == "news"
-    assert meta["engine_attempts"][0]["engines"] == ["reuters", "yahoo news", "bing news"]
+    assert meta["engine_attempts"][0]["engines"] == ["reuters", "bing news", "duckduckgo news", "wikinews"]
+
+
+def test_provider_stats_and_health_record_direct_attempts(monkeypatch: pytest.MonkeyPatch, client: AppClient) -> None:
+    fake = EngineAwareFakeSearxngClient()
+    monkeypatch.setattr(main, "http_client", fake)
+
+    response = client.get("/search/strategy", params={"q": "fetch api", "count": 10, "mode": "code"})
+    assert response.status_code == 200
+
+    stats = client.get("/providers/stats")
+    assert stats.status_code == 200
+    providers = {
+        (row["source"], row["name"]): row
+        for row in stats.json()["providers"]
+    }
+    for name in ["github", "mdn", "docker_hub", "pypi"]:
+        row = providers[("provider", name)]
+        assert row["attempts"] == 1
+        assert row["successes"] == 1
+        assert row["health"] == "healthy"
+
+    health = client.get("/providers/health")
+    assert health.status_code == 200
+    data = health.json()
+    assert data["status"] == "healthy"
+    assert data["attempted"] >= 4
+
+
+def test_search_records_searxng_error_attempt(monkeypatch: pytest.MonkeyPatch, client: AppClient) -> None:
+    monkeypatch.setattr(main, "http_client", RaisingSearchFakeSearxngClient())
+
+    response = client.get("/search", params={"q": "timeout", "count": 1})
+    assert response.status_code == 502
+
+    stats = client.get("/providers/stats")
+    assert stats.status_code == 200
+    providers = {
+        (row["source"], row["name"]): row
+        for row in stats.json()["providers"]
+    }
+    row = providers[("searxng", "default")]
+    assert row["attempts"] == 1
+    assert row["errors"] == 1
+    assert row["health"] == "error"
+    assert "SearXNG error" in row["last_error"]
+
+
+def test_news_records_searxng_error_attempt(monkeypatch: pytest.MonkeyPatch, client: AppClient) -> None:
+    monkeypatch.setattr(main, "http_client", RaisingSearchFakeSearxngClient())
+
+    response = client.get("/news", params={"q": "timeout", "count": 1})
+    assert response.status_code == 502
+
+    stats = client.get("/providers/stats")
+    assert stats.status_code == 200
+    providers = {
+        (row["source"], row["name"]): row
+        for row in stats.json()["providers"]
+    }
+    row = providers[("searxng", main.NEWS_ENGINES)]
+    assert row["attempts"] == 1
+    assert row["errors"] == 1
+    assert row["health"] == "error"
+    assert "SearXNG error" in row["last_error"]
 
 
 def test_domain_filter_does_not_site_scope_non_web_engines(monkeypatch: pytest.MonkeyPatch, client: AppClient) -> None:


### PR DESCRIPTION
## Summary

- Add direct no-key providers for PyPI, Wikipedia, Wikidata, Hacker News, and Reddit.
- Add provider attempt telemetry plus `/providers/stats` and `/providers/health` so failing engines are visible instead of silently falling through.
- Update strategy modes to prefer reliable direct providers and avoid known-problem default packs for Google, Startpage, Yahoo, and Reddit while keeping them available as explicit best-effort sources.
- Expand SDK, MCP tools, docs, and tests for the new providers, modes, and telemetry endpoints.

## Why

AgentSearch was falling back through failing upstream search engines without enough observability. The best next fix is to make provider attempts explicit, add reliable no-key direct providers, and make strategy defaults choose engines that return usable rows in live testing.

## Validation

- `python3 -m pytest -q` -> 51 passed, 10 skipped
- `python3 -m compileall app adapters mcp-server/agent_search_mcp scripts sdk -q`
- `git diff --check`
- Rebuilt/restarted Docker compose stack from current source
- Live `mode=community` probe returned non-empty Hacker News results without Reddit fallback
- `/providers/health` reported provider telemetry
- `AGENTSEARCH_DOCKER_INTEGRATION=1 python3 -m pytest tests/test_live_docker.py -q` -> 9 passed