### PR TITLE
[codex] Fix live PyPI provider lookup

### DIFF
--- a/app/search_providers.py
+++ b/app/search_providers.py
@@ -115,31 +115,6 @@ def _json_items(data: Any, *path: str) -> list:
     return current if isinstance(current, list) else []
 
 
-def _html_attr(tag: str, attr: str) -> str:
-    match = re.search(rf"\b{re.escape(attr)}\s*=\s*([\"'])(.*?)\1", tag, flags=re.IGNORECASE | re.DOTALL)
-    return _safe_text(unescape(match.group(2)), limit=500) if match else ""
-
-
-def _html_anchors_with_class(html: str, class_name: str) -> list[tuple[str, str]]:
-    anchors: list[tuple[str, str]] = []
-    for match in re.finditer(r"(<a\b[^>]*>)(.*?)</a>", html, flags=re.IGNORECASE | re.DOTALL):
-        tag, body = match.groups()
-        classes = _html_attr(tag, "class").split()
-        if class_name in classes:
-            anchors.append((tag, body))
-    return anchors
-
-
-def _html_class_text(html: str, class_name: str) -> str:
-    class_pattern = re.escape(class_name)
-    match = re.search(
-        rf"<[^>]*\bclass\s*=\s*([\"'])[^\"']*\b{class_pattern}\b[^\"']*\1[^>]*>(.*?)</[^>]+>",
-        html,
-        flags=re.IGNORECASE | re.DOTALL,
-    )
-    return _clean_snippet(match.group(2)) if match else ""
-
-
 def _abstract_from_openalex_index(index: object) -> str:
     if not isinstance(index, dict):
         return ""
@@ -160,6 +135,41 @@ def _doi_url(doi: object) -> str:
     if doi_text.startswith("http://") or doi_text.startswith("https://"):
         return doi_text
     return f"https://doi.org/{doi_text}"
+
+
+def _query_tokens(query: str) -> list[str]:
+    tokens: list[str] = []
+    skip = {
+        "a",
+        "an",
+        "and",
+        "api",
+        "for",
+        "in",
+        "library",
+        "module",
+        "package",
+        "packages",
+        "python",
+        "the",
+        "tool",
+        "with",
+    }
+    for token in re.findall(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,80}", query):
+        normalized = token.strip("._-").lower()
+        if normalized and normalized not in skip and normalized not in tokens:
+            tokens.append(normalized)
+    return tokens
+
+
+_PYPI_PROJECT_RE = re.compile(r"^[a-z0-9](?:[a-z0-9._-]{0,78}[a-z0-9])?$")
+
+
+def _pypi_json_url(project_name: str) -> httpx.URL | None:
+    if not _PYPI_PROJECT_RE.fullmatch(project_name):
+        return None
+    path = f"/pypi/{project_name}/json"
+    return httpx.URL("https://pypi.org").copy_with(path=path)
 
 
 class MDNProvider(SearchProvider):
@@ -260,34 +270,33 @@ class PyPIProvider(SearchProvider):
     engine_name = "pypi"
 
     async def _search(self, client: httpx.AsyncClient, query: str, count: int) -> list[dict]:
-        resp = await client.get(
-            "https://pypi.org/search/",
-            params={"q": query},
-            headers=DEFAULT_PROVIDER_HEADERS,
-            timeout=self.timeout,
-        )
-        resp.raise_for_status()
-
         results: list[dict] = []
-        for tag, block in _html_anchors_with_class(resp.text, "package-snippet"):
-            href = _html_attr(tag, "href")
-            if not href.startswith("/project/"):
+        for token in _query_tokens(query)[: min(max(count * 2, 1), 12)]:
+            url = _pypi_json_url(token)
+            if url is None:
                 continue
-            package_name = _html_class_text(block, "package-snippet__name")
+            resp = await client.get(
+                url,
+                headers=DEFAULT_PROVIDER_HEADERS,
+                timeout=self.timeout,
+            )
+            if getattr(resp, "status_code", 200) == 404:
+                continue
+            resp.raise_for_status()
+            data = resp.json()
+            info = data.get("info") if isinstance(data, dict) else {}
+            if not isinstance(info, dict):
+                continue
+            package_name = _safe_text(info.get("name") or token)
             if not package_name:
                 continue
-            version = _html_class_text(block, "package-snippet__version")
-            description = _html_class_text(block, "package-snippet__description")
-            snippet = description
+            project_url = _safe_text(info.get("package_url")) or f"https://pypi.org/project/{quote(package_name)}/"
+            summary = info.get("summary") or info.get("description") or ""
+            version = info.get("version")
+            snippet = _safe_text(summary, limit=800)
             if version:
                 snippet = f"{snippet} Version: {version}".strip()
-            results.append(
-                self._result(
-                    package_name,
-                    urljoin("https://pypi.org", href),
-                    snippet,
-                )
-            )
+            results.append(self._result(package_name, project_url, snippet))
             if len(results) >= count * 3:
                 break
         return results

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -138,7 +138,7 @@ class EngineAwareFakeSearxngClient:
         self.mdn_params: list[dict] = []
         self.github_params: list[dict] = []
         self.docker_hub_params: list[dict] = []
-        self.pypi_params: list[dict] = []
+        self.pypi_packages: list[str] = []
         self.wikipedia_params: list[dict] = []
         self.wikidata_params: list[dict] = []
         self.hackernews_params: list[dict] = []
@@ -149,6 +149,7 @@ class EngineAwareFakeSearxngClient:
         self.semantic_scholar_params: list[dict] = []
 
     async def get(self, url: str, params: dict | None = None, timeout: float | None = None, **kwargs) -> FakeResponse:
+        url = str(url)
         if url.startswith("https://developer.mozilla.org/api/v1/search"):
             self.mdn_params.append(dict(params or {}))
             return FakeResponse({
@@ -183,15 +184,17 @@ class EngineAwareFakeSearxngClient:
                     }
                 ]
             })
-        if url.startswith("https://pypi.org/search/"):
-            self.pypi_params.append(dict(params or {}))
-            return FakeResponse({}, text="""
-                <a class="package-snippet" href="/project/fastapi/">
-                  <span class="package-snippet__name">fastapi</span>
-                  <span class="package-snippet__version">1.0.0</span>
-                  <p class="package-snippet__description">FastAPI framework</p>
-                </a>
-            """)
+        if url.startswith("https://pypi.org/pypi/") and url.endswith("/json"):
+            package = url.removeprefix("https://pypi.org/pypi/").removesuffix("/json")
+            self.pypi_packages.append(package)
+            return FakeResponse({
+                "info": {
+                    "name": package,
+                    "package_url": f"https://pypi.org/project/{package}/",
+                    "summary": f"{package} Python package",
+                    "version": "1.0.0",
+                }
+            })
         if url.startswith("https://en.wikipedia.org/w/api.php"):
             self.wikipedia_params.append(dict(params or {}))
             return FakeResponse({
@@ -586,7 +589,7 @@ def test_search_strategy_code_uses_direct_code_providers(monkeypatch: pytest.Mon
     assert fake.github_params[0]["q"] == "fetch api"
     assert fake.mdn_params == [{"q": "fetch api", "locale": "en-US"}]
     assert fake.docker_hub_params[0]["query"] == "fetch api"
-    assert fake.pypi_params == [{"q": "fetch api"}]
+    assert fake.pypi_packages == ["fetch"]
     assert [attempt["engines"] for attempt in data["meta"]["engine_attempts"]] == [
         ["github"],
         ["mdn"],


### PR DESCRIPTION
## Summary

- Replace the PyPI `/search/` HTML lookup with exact package JSON metadata lookups.
- Keep user input constrained to sanitized PyPI project-name candidates before constructing fixed-host PyPI JSON URLs.
- Restore tests around package candidate behavior.

## Why

Live redeploy testing showed `https://pypi.org/search/?q=fastapi` returns a client challenge page from the API container, so the provider returned zero rows even though PyPI JSON metadata works without a paid API.

## Validation

- `python3 -m pytest tests/test_api.py::test_search_strategy_code_uses_direct_code_providers tests/test_api.py::test_provider_stats_and_health_record_direct_attempts -q` -> 2 passed
- `python3 -m compileall app adapters mcp-server/agent_search_mcp scripts sdk -q`
- `git diff --check`
- `python3 -m pytest -q` -> 53 passed, 10 skipped
- Live PyPI provider probe for `fastapi` -> status ok, 1 result