### PR TITLE
[codex] Ensure strategy provider result coverage

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -739,6 +739,54 @@ def _filter_search_results(
     return results
 
 
+def _result_key(result: SearchResult) -> str:
+    return result.url.rstrip("/")
+
+
+def _renumber_results(results: list[SearchResult]) -> None:
+    for index, result in enumerate(results, start=1):
+        result.position = index
+
+
+def _ensure_strategy_coverage(
+    ranked_results: list[SearchResult],
+    coverage_groups: list[list[SearchResult]],
+    count: int,
+) -> list[SearchResult]:
+    selected = list(ranked_results[:count])
+    if count <= 1 or not selected:
+        return selected
+
+    selected_keys = {_result_key(result) for result in selected}
+    replace_at = len(selected) - 1
+
+    for group in coverage_groups:
+        if any(_result_key(result) in selected_keys for result in group):
+            continue
+
+        candidate = next((result for result in group if _result_key(result) not in selected_keys), None)
+        if candidate is None:
+            continue
+
+        candidate_key = _result_key(candidate)
+        if len(selected) < count:
+            selected.append(candidate)
+            selected_keys.add(candidate_key)
+            continue
+
+        if replace_at <= 0:
+            break
+
+        removed = selected[replace_at]
+        selected[replace_at] = candidate
+        selected_keys.discard(_result_key(removed))
+        selected_keys.add(candidate_key)
+        replace_at -= 1
+
+    _renumber_results(selected)
+    return selected
+
+
 async def _attach_content(results: list[SearchResult]) -> None:
     if not results:
         return
@@ -786,6 +834,7 @@ async def _search_strategy_impl(
         return cached_resp
 
     combined_raw: list[dict] = []
+    coverage_groups: list[list[SearchResult]] = []
     upstream_responses: list[SearxngQueryResponse] = []
     engine_attempts: list[dict] = []
     queries_used: list[str] = []
@@ -829,6 +878,13 @@ async def _search_strategy_impl(
 
         upstream_responses.append(upstream)
         combined_raw.extend(upstream.results)
+        pack_results = _filter_search_results(
+            deduplicate_with_scoring(upstream.results),
+            domain=domain,
+            exclude_domains=exclude_domains,
+        )
+        if pack_results:
+            coverage_groups.append(pack_results)
         current_results = _filter_search_results(
             deduplicate_with_scoring(combined_raw),
             domain=domain,
@@ -870,11 +926,12 @@ async def _search_strategy_impl(
         if normalized_mode == "general" and index < len(SEARCH_STRATEGY_MODES[normalized_mode]) - 1:
             fallback_reason = "no_results" if not upstream.results else "insufficient_results"
 
-    results = _filter_search_results(
+    ranked_results = _filter_search_results(
         deduplicate_with_scoring(combined_raw),
         domain=domain,
         exclude_domains=exclude_domains,
-    )[:count]
+    )
+    results = _ensure_strategy_coverage(ranked_results, coverage_groups, count)
 
     if fetch:
         await _attach_content(results)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -735,6 +735,37 @@ def test_news_records_searxng_error_attempt(monkeypatch: pytest.MonkeyPatch, cli
     assert "SearXNG error" in row["last_error"]
 
 
+def test_strategy_coverage_preserves_successful_provider_rows() -> None:
+    def result(title: str, url: str, engine: str, position: int) -> main.SearchResult:
+        return main.SearchResult(
+            title=title,
+            url=url,
+            snippet="snippet",
+            engines=[engine],
+            score=100 - position,
+            position=position,
+        )
+
+    github_results = [
+        result(f"github {index}", f"https://github.com/example/{index}", "github", index)
+        for index in range(1, 8)
+    ]
+    docker_result = result("docker", "https://hub.docker.com/r/example/app", "docker hub", 8)
+    pypi_result = result("pypi", "https://pypi.org/project/example/", "pypi", 9)
+
+    selected = main._ensure_strategy_coverage(
+        ranked_results=github_results,
+        coverage_groups=[github_results, [docker_result], [pypi_result]],
+        count=5,
+    )
+
+    assert selected[0].engines == ["github"]
+    assert len(selected) == 5
+    assert "docker hub" in {engine for item in selected for engine in item.engines}
+    assert "pypi" in {engine for item in selected for engine in item.engines}
+    assert [item.position for item in selected] == [1, 2, 3, 4, 5]
+
+
 def test_domain_filter_does_not_site_scope_non_web_engines(monkeypatch: pytest.MonkeyPatch, client: AppClient) -> None:
     fake = EngineAwareFakeSearxngClient()
     monkeypatch.setattr(main, "http_client", fake)


### PR DESCRIPTION
## Summary

- Add a final strategy result coverage pass that keeps the top-ranked result but replaces tail results with representatives from successful provider packs when needed.
- Track per-pack deduped candidates during strategy execution.
- Add a regression test so provider rows do not remain metadata-only when one source dominates ranking.

## Why

Live code-mode testing showed PyPI returned a raw result after the provider fix, but GitHub filled the returned window. This made the provider technically attempted but not practically visible to callers.

## Validation

- `python3 -m pytest tests/test_api.py::test_strategy_coverage_preserves_successful_provider_rows -q` -> 1 passed
- Earlier full suite after the same working-set changes: `python3 -m pytest -q` -> 54 passed, 10 skipped