### PR TITLE
[codex] Add browser render extraction provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 ARG PYTHON_BASE_IMAGE=python@sha256:9e01bf1ae5db7649a236da7be1e94ffbbbdd7a93f867dd0d8d5720d9e1f89fab
 FROM ${PYTHON_BASE_IMAGE}
 
-# System deps for PDF extraction and yt-dlp
+# System deps for PDF extraction, yt-dlp, and browser-render extraction
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    chromium \
     ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AgentSearch
 
-Self-hosted search API for AI agents. 16 endpoints. 9-strategy content extraction. Optional Tor-anonymized stack. No third-party search API keys, no per-query fees, no vendor lock-in. Optional local bearer auth is supported.
+Self-hosted search API for AI agents. 17 endpoints. Kill-chain content extraction with optional browser rendering. Optional Tor-anonymized stack. No third-party search API keys, no per-query fees, no vendor lock-in. Optional local bearer auth is supported.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![PyPI](https://img.shields.io/pypi/v/agentsearch-client)](https://pypi.org/project/agentsearch-client/)
 
@@ -100,13 +100,13 @@ Strategy modes can also use direct no-key providers for vertical search. These d
 
 ## Why not just use SearXNG directly?
 
-SearXNG finds pages. AgentSearch finds pages, reads them, scores them, deduplicates them, caches them, scrubs prompt injections out of them, detects paywalls, falls back through 9 extraction strategies when the first one fails, and gets better at it over time. One API call.
+SearXNG finds pages. AgentSearch finds pages, reads them, scores them, deduplicates them, caches them, scrubs prompt injections out of them, detects paywalls, falls back through escalating extraction strategies when the first one fails, and gets better at it over time. One API call.
 
 | | AgentSearch | Tavily | Exa | SerpAPI | Raw SearXNG |
 |---|---|---|---|---|---|
 | **Cost** | Free | $0.005/query | $0.001/query | $50/mo | Free |
 | **Self-hosted** | ✅ | ❌ | ❌ | ❌ | ✅ |
-| **Content extraction** | 9-strategy kill chain | Basic | Basic | ❌ | ❌ |
+| **Content extraction** | Kill chain + browser renderer | Basic | Basic | ❌ | ❌ |
 | **Deduplication** | Cross-engine | ❌ | ❌ | ❌ | ❌ |
 | **Prompt injection scrubbing** | ✅ | ❌ | ❌ | ❌ | ❌ |
 | **Self-improving** | ✅ (evolver) | ❌ | ❌ | ❌ | ❌ |
@@ -133,22 +133,24 @@ SearXNG finds pages. AgentSearch finds pages, reads them, scores them, deduplica
 
 | Endpoint | Method | What it does |
 |---|---|---|
-| `/read` | GET | 9-strategy kill chain extraction for any URL |
+| `/read` | GET | Kill chain extraction for any URL |
 | `/read/batch` | POST | Concurrent multi-URL extraction in one request |
+| `/providers/browser/fetch` | GET | Ephemeral browser render/extract for JS-rendered target pages |
 
 The kill chain escalates through strategies until one succeeds:
 
 1. Direct fetch + smart content selectors
 2. Readability scoring (paragraph density vs link density)
 3. User-agent rotation (Chrome/Safari/Firefox/Edge signatures)
-4. Wayback Machine (CDX API → latest snapshot)
-5. Google Cache
-6. Search-about fallback (find coverage elsewhere)
-7. Custom adapters (pluggable Python modules from disk)
-8. PDF extraction (pdfplumber)
-9. YouTube transcript (yt-dlp)
+4. Browser render/extract for JS-rendered target pages
+5. Wayback Machine (CDX API → latest snapshot)
+6. Google Cache
+7. Search-about fallback (find coverage elsewhere)
+8. Custom adapters (pluggable Python modules from disk)
+9. PDF extraction (pdfplumber)
+10. YouTube transcript (yt-dlp)
 
-Every request gets SSRF protection, prompt injection detection, paywall detection, and content length caps automatically.
+Every request gets SSRF protection, prompt injection detection, paywall detection, and content length caps automatically. The browser renderer uses an ephemeral context, blocks high-cost resource types by default, and reports CAPTCHA/challenge pages instead of trying to bypass them. It is for rendering target pages, not for scraping blocked search-result pages.
 
 ### Self-improvement
 
@@ -223,6 +225,14 @@ curl "http://localhost:3939/read?url=https://example.com/paywalled-article"
 }
 ```
 
+### Browser render a JS page
+
+```bash
+curl "http://localhost:3939/providers/browser/fetch?url=https://example.com/app&max_links=20"
+```
+
+Returns rendered text, page title, final URL, extracted links, trust metadata, and `challenge_detected=true` if the page is a CAPTCHA or bot challenge.
+
 ### Batch read
 
 ```bash
@@ -248,6 +258,10 @@ for r in results.results:
 # Content extraction
 page = client.read("https://example.com/article")
 print(page.content[:500])
+
+# Browser-rendered extraction for JS-heavy target pages
+rendered = client.browser_fetch("https://example.com/app", max_links=20)
+print(rendered.title, rendered.links[:3])
 
 # Batch read
 pages = client.read_batch(["https://a.com", "https://b.com"])
@@ -359,8 +373,9 @@ Port 3939 (direct)                    Port 3940 (Tor-anonymized)
 
 | Module | LOC | What it does |
 |---|---|---|
-| `killchain.py` | 1016 | 9-strategy escalating content extraction |
-| `main.py` | 920 | FastAPI app, 16 endpoints, auth, rate limiting |
+| `killchain.py` | 1016 | Escalating content extraction and browser-render fallback |
+| `browser_renderer.py` | 320 | Ephemeral browser rendering, extraction, and challenge detection |
+| `main.py` | 920 | FastAPI app, 17 endpoints, auth, rate limiting |
 | `source_tracer.py` | 620 | Source provenance tracking and citation chains |
 | `scrubber.py` | 539 | Prompt injection detection and content sanitization |
 | `source_library.py` | 310 | Curated institutional source registry |

--- a/app/browser_renderer.py
+++ b/app/browser_renderer.py
@@ -18,7 +18,7 @@ from urllib.parse import urlparse
 from bs4 import BeautifulSoup
 
 from app.domain_trust import TrustResult, evaluate_trust
-from app.killchain import (
+from app.fetch_policy import (
     MAX_CONTENT_CHARS,
     MIN_USEFUL_CHARS,
     USER_AGENTS,
@@ -248,6 +248,7 @@ async def render_browser_page(
             try:
                 await page.wait_for_load_state("networkidle", timeout=min(3000, effective_timeout_ms))
             except PlaywrightTimeoutError:
+                # Network-idle is best effort; DOM content is enough for extraction.
                 pass
 
             final_url = page.url
@@ -272,6 +273,15 @@ async def render_browser_page(
             except Exception:
                 body_text = ""
 
+            status = response.status if response is not None else None
+            if status is not None and status >= 400:
+                return _result(
+                    final_url=final_url,
+                    title=title,
+                    error=f"Rendered navigation returned HTTP {status}",
+                    blocked_reason="http_error",
+                )
+
             challenge_detected = detect_browser_challenge(title, body_text, html)
             if challenge_detected:
                 return _result(
@@ -291,7 +301,6 @@ async def render_browser_page(
             links = _extract_links(raw_links if isinstance(raw_links, list) else [], effective_max_links)
             content = extract_rendered_content(html, body_text, effective_max_chars)
             if not content:
-                status = response.status if response is not None else None
                 return _result(
                     final_url=final_url,
                     title=title,
@@ -314,9 +323,11 @@ async def render_browser_page(
             try:
                 await context.close()
             except Exception:
+                # Playwright may already close the context after navigation-level failures.
                 pass
         if browser is not None:
             try:
                 await browser.close()
             except Exception:
+                # Browser teardown should not override the render result.
                 pass

--- a/app/browser_renderer.py
+++ b/app/browser_renderer.py
@@ -1,0 +1,322 @@
+"""Bounded browser rendering and extraction.
+
+This module is intentionally a renderer/extractor, not a bot-evasion layer. It
+does not solve CAPTCHAs, use persistent profiles, log in, or try to bypass
+search-engine blocking. It loads a safe URL in a temporary browser context,
+extracts readable text and links, and reports challenge/block pages as failures.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
+
+from app.domain_trust import TrustResult, evaluate_trust
+from app.killchain import (
+    MAX_CONTENT_CHARS,
+    MIN_USEFUL_CHARS,
+    USER_AGENTS,
+    clean_html,
+    is_safe_url,
+    sanitize_content,
+)
+
+
+BROWSER_RENDER_ENABLED = os.getenv("BROWSER_RENDER_ENABLED", "1").lower() not in {"0", "false", "no", "off"}
+BROWSER_RENDER_TIMEOUT_MS = int(os.getenv("BROWSER_RENDER_TIMEOUT_MS", "15000"))
+BROWSER_RENDER_MAX_LINKS = int(os.getenv("BROWSER_RENDER_MAX_LINKS", "50"))
+BROWSER_RENDER_BLOCKED_DOMAINS = {
+    domain.strip().lower()
+    for domain in os.getenv(
+        "BROWSER_RENDER_BLOCKED_DOMAINS",
+        ",".join([
+            "google.com",
+            "bing.com",
+            "search.yahoo.com",
+            "startpage.com",
+            "duckduckgo.com",
+        ]),
+    ).split(",")
+    if domain.strip()
+}
+BROWSER_BLOCKED_RESOURCE_TYPES = {
+    item.strip().lower()
+    for item in os.getenv("BROWSER_BLOCKED_RESOURCE_TYPES", "image,media,font").split(",")
+    if item.strip()
+}
+
+CHALLENGE_SIGNALS = [
+    "captcha",
+    "checking your browser",
+    "client challenge",
+    "verify you are human",
+    "are you a robot",
+    "unusual traffic",
+    "access denied",
+    "enable javascript and cookies",
+    "cloudflare ray id",
+    "too many requests",
+]
+
+
+@dataclass
+class BrowserLink:
+    """A link extracted from a rendered page."""
+
+    text: str
+    url: str
+
+
+@dataclass
+class BrowserRenderResult:
+    """Result from a bounded browser render attempt."""
+
+    url: str
+    final_url: str = ""
+    title: str = ""
+    content: str | None = None
+    chars: int = 0
+    links: list[BrowserLink] = field(default_factory=list)
+    success: bool = False
+    strategy: str = "browser-render"
+    error: str | None = None
+    challenge_detected: bool = False
+    blocked_reason: str | None = None
+    render_time_ms: float = 0.0
+    trust: TrustResult | None = None
+
+
+def _hostname(url: str) -> str:
+    return (urlparse(url).hostname or "").lower()
+
+
+def _host_matches(hostname: str, domain: str) -> bool:
+    hostname = hostname.lower().removeprefix("www.")
+    domain = domain.lower().removeprefix("www.")
+    return hostname == domain or hostname.endswith("." + domain)
+
+
+def _blocked_browser_domain(url: str) -> str | None:
+    hostname = _hostname(url)
+    for domain in BROWSER_RENDER_BLOCKED_DOMAINS:
+        if _host_matches(hostname, domain):
+            return f"Browser rendering disabled for search-engine domain '{domain}'"
+    return None
+
+
+def _default_chromium_path() -> str | None:
+    explicit = os.getenv("BROWSER_CHROMIUM_PATH", "").strip()
+    if explicit:
+        return explicit
+    for candidate in [
+        "/usr/bin/chromium",
+        "/usr/bin/chromium-browser",
+        "/usr/bin/google-chrome",
+        "/usr/bin/google-chrome-stable",
+    ]:
+        if Path(candidate).exists():
+            return candidate
+    return None
+
+
+def detect_browser_challenge(title: str, text: str, html: str) -> bool:
+    haystack = f"{title}\n{text[:5000]}\n{html[:5000]}".lower()
+    return any(signal in haystack for signal in CHALLENGE_SIGNALS)
+
+
+def _clean_link_text(value: object, limit: int = 140) -> str:
+    text = "" if value is None else str(value)
+    text = " ".join(text.split())
+    return text[:limit]
+
+
+def _extract_links(raw_links: list[dict[str, Any]], max_links: int) -> list[BrowserLink]:
+    links: list[BrowserLink] = []
+    seen: set[str] = set()
+    for item in raw_links:
+        href = str(item.get("href") or "").strip()
+        if not href or href in seen:
+            continue
+        if not href.startswith(("http://", "https://")):
+            continue
+        if not is_safe_url(href):
+            continue
+        text = _clean_link_text(item.get("text")) or href
+        links.append(BrowserLink(text=text, url=href))
+        seen.add(href)
+        if len(links) >= max_links:
+            break
+    return links
+
+
+def extract_rendered_content(html: str, body_text: str, max_chars: int) -> str | None:
+    content = clean_html(html)
+    if not content and body_text:
+        soup = BeautifulSoup(body_text, "html.parser")
+        content = soup.get_text(separator="\n", strip=True) or body_text
+    if not content:
+        return None
+    content = sanitize_content(content)[:max_chars]
+    if len(content.strip()) < MIN_USEFUL_CHARS:
+        return None
+    return content
+
+
+async def render_browser_page(
+    url: str,
+    *,
+    max_chars: int | None = None,
+    max_links: int | None = None,
+    timeout_ms: int | None = None,
+) -> BrowserRenderResult:
+    """Render a URL in an ephemeral browser context and extract text/links."""
+    start = time.monotonic()
+    effective_max_chars = max_chars or MAX_CONTENT_CHARS
+    effective_max_links = max_links if max_links is not None else BROWSER_RENDER_MAX_LINKS
+    effective_timeout_ms = timeout_ms or BROWSER_RENDER_TIMEOUT_MS
+    trust = evaluate_trust(url, check_whois=False)
+
+    def _result(**kwargs: Any) -> BrowserRenderResult:
+        result = BrowserRenderResult(url=url, trust=trust, **kwargs)
+        result.render_time_ms = round((time.monotonic() - start) * 1000, 1)
+        return result
+
+    if not BROWSER_RENDER_ENABLED:
+        return _result(error="Browser rendering is disabled", blocked_reason="disabled")
+    if not is_safe_url(url, verbose=True):
+        return _result(error="URL blocked by safety check", blocked_reason="unsafe_url")
+    blocked_reason = _blocked_browser_domain(url)
+    if blocked_reason:
+        return _result(error=blocked_reason, blocked_reason=blocked_reason)
+
+    try:
+        from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+        from playwright.async_api import async_playwright
+    except Exception as exc:
+        return _result(error=f"Playwright unavailable: {type(exc).__name__}: {exc}")
+
+    browser = None
+    context = None
+    try:
+        async with async_playwright() as pw:
+            executable_path = _default_chromium_path()
+            browser = await pw.chromium.launch(
+                headless=True,
+                executable_path=executable_path,
+                args=[
+                    "--no-sandbox",
+                    "--disable-dev-shm-usage",
+                    "--disable-gpu",
+                    "--disable-extensions",
+                    "--disable-background-networking",
+                ],
+            )
+            context = await browser.new_context(
+                user_agent=USER_AGENTS[0],
+                viewport={"width": 1365, "height": 768},
+                locale="en-US",
+                timezone_id="UTC",
+                ignore_https_errors=False,
+            )
+            page = await context.new_page()
+
+            safety_cache: dict[str, bool] = {}
+
+            async def _route(route: Any) -> None:
+                request = route.request
+                if request.resource_type in BROWSER_BLOCKED_RESOURCE_TYPES:
+                    await route.abort()
+                    return
+                request_url = request.url
+                safe = safety_cache.get(request_url)
+                if safe is None:
+                    safe = is_safe_url(request_url)
+                    safety_cache[request_url] = safe
+                if not safe:
+                    await route.abort()
+                    return
+                await route.continue_()
+
+            await page.route("**/*", _route)
+            response = await page.goto(url, wait_until="domcontentloaded", timeout=effective_timeout_ms)
+            try:
+                await page.wait_for_load_state("networkidle", timeout=min(3000, effective_timeout_ms))
+            except PlaywrightTimeoutError:
+                pass
+
+            final_url = page.url
+            if not is_safe_url(final_url, verbose=True):
+                return _result(
+                    final_url=final_url,
+                    error="Rendered navigation ended at an unsafe URL",
+                    blocked_reason="unsafe_final_url",
+                )
+            final_blocked_reason = _blocked_browser_domain(final_url)
+            if final_blocked_reason:
+                return _result(
+                    final_url=final_url,
+                    error=final_blocked_reason,
+                    blocked_reason=final_blocked_reason,
+                )
+
+            title = await page.title()
+            html = await page.content()
+            try:
+                body_text = await page.locator("body").inner_text(timeout=1000)
+            except Exception:
+                body_text = ""
+
+            challenge_detected = detect_browser_challenge(title, body_text, html)
+            if challenge_detected:
+                return _result(
+                    final_url=final_url,
+                    title=title,
+                    error="Challenge or block page detected; browser renderer will not bypass it",
+                    challenge_detected=True,
+                )
+
+            raw_links = await page.evaluate(
+                """(maxLinks) => Array.from(document.links).slice(0, maxLinks * 3).map((a) => ({
+                    text: (a.innerText || a.textContent || '').trim(),
+                    href: a.href || ''
+                }))""",
+                effective_max_links,
+            )
+            links = _extract_links(raw_links if isinstance(raw_links, list) else [], effective_max_links)
+            content = extract_rendered_content(html, body_text, effective_max_chars)
+            if not content:
+                status = response.status if response is not None else None
+                return _result(
+                    final_url=final_url,
+                    title=title,
+                    links=links,
+                    error=f"Rendered page produced no useful content (status={status})",
+                )
+
+            return _result(
+                final_url=final_url,
+                title=title,
+                content=content,
+                chars=len(content),
+                links=links,
+                success=True,
+            )
+    except Exception as exc:
+        return _result(error=f"{type(exc).__name__}: {exc}")
+    finally:
+        if context is not None:
+            try:
+                await context.close()
+            except Exception:
+                pass
+        if browser is not None:
+            try:
+                await browser.close()
+            except Exception:
+                pass

--- a/app/fetch_policy.py
+++ b/app/fetch_policy.py
@@ -1,0 +1,195 @@
+"""Shared fetch safety and content extraction helpers."""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import socket
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
+
+from app.scrubber import scrub_content
+
+
+logger = logging.getLogger("agentsearch.fetch_policy")
+
+USER_AGENTS = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15",
+    "Mozilla/5.0 (X11; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/133.0",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0",
+]
+
+CONTENT_SELECTORS = [
+    "main", "article", "[role=main]", ".content", "#content",
+    ".post-content", ".entry-content", ".article-body", ".post-body",
+    ".story-body", ".td-post-content", ".blog-content", ".page-content",
+    "#article-body", ".article__body", ".article-text",
+]
+
+GARBAGE_TAGS = [
+    "script", "style", "nav", "footer", "header", "aside",
+    "iframe", "noscript", "svg", "form",
+]
+
+GARBAGE_CLASSES = [
+    ".sidebar", ".comments", ".related", ".advertisement", ".ad",
+    ".social-share", ".newsletter-signup", ".cookie-banner",
+    ".popup", ".modal", ".nav-menu", ".breadcrumb",
+]
+
+MAX_CONTENT_CHARS = 15_000
+MIN_USEFUL_CHARS = 200
+
+BLOCKED_FETCH_DOMAINS = {
+    "bit.ly", "tinyurl.com", "t.co", "goo.gl", "ow.ly",
+    "buff.ly", "is.gd", "v.gd", "short.io",
+    "media.defense.gov",
+    "www.iiss.org",
+    "saisreview.sais.jhu.edu",
+    "barrywehmiller.wd1.myworkdayjobs.com",
+}
+
+DYNAMIC_BLOCKLIST_PATH = Path(os.getenv("DATA_DIR", "data")) / "blocked_domains.txt"
+
+SUSPICIOUS_TLDS = {
+    ".tk", ".ml", ".ga", ".cf", ".gq",
+    ".buzz", ".top", ".xyz", ".work", ".click",
+}
+
+
+def _safe_log_value(value: object, limit: int = 200) -> str:
+    text = str(value).replace("\r", "\\r").replace("\n", "\\n")
+    return text[:limit]
+
+
+def _load_dynamic_blocklist() -> set[str]:
+    try:
+        if DYNAMIC_BLOCKLIST_PATH.exists():
+            domains = set()
+            for line in DYNAMIC_BLOCKLIST_PATH.read_text().splitlines():
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    domains.add(line.lower())
+            return domains
+    except Exception as exc:
+        logger.debug("Failed to load dynamic blocklist: %s", exc)
+    return set()
+
+
+def get_blocked_domains() -> set[str]:
+    """Return the full set of blocked domains."""
+    return BLOCKED_FETCH_DOMAINS | _load_dynamic_blocklist()
+
+
+def is_safe_url(url: str, verbose: bool = False) -> bool:
+    """Validate a URL before fetching or rendering it."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return False
+
+    if parsed.scheme not in ("http", "https"):
+        if verbose:
+            logger.warning("BLOCKED: non-HTTP scheme '%s'", _safe_log_value(parsed.scheme))
+        return False
+
+    hostname = parsed.hostname
+    if not hostname:
+        if verbose:
+            logger.warning("BLOCKED: no hostname in URL")
+        return False
+
+    if parsed.scheme == "http" and verbose:
+        logger.warning("DEGRADED: plain HTTP URL (no TLS) - %s", _safe_log_value(hostname))
+
+    hostname_lower = hostname.lower()
+    if hostname_lower in ("localhost", "localhost.localdomain", "127.0.0.1", "::1", "0.0.0.0"):
+        if verbose:
+            logger.warning("BLOCKED: localhost/loopback")
+        return False
+
+    for blocked in get_blocked_domains():
+        if hostname_lower == blocked or hostname_lower.endswith("." + blocked):
+            if verbose:
+                logger.warning("BLOCKED: blocked domain '%s'", _safe_log_value(blocked))
+            return False
+
+    for tld in SUSPICIOUS_TLDS:
+        if hostname_lower.endswith(tld):
+            if verbose:
+                logger.warning("BLOCKED: suspicious TLD '%s'", _safe_log_value(tld))
+            return False
+
+    try:
+        addr = ipaddress.ip_address(hostname)
+        if addr.is_private or addr.is_reserved or addr.is_loopback or addr.is_link_local:
+            if verbose:
+                logger.warning("BLOCKED: private/reserved IP %s", addr)
+            return False
+    except ValueError:
+        try:
+            resolved = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+            for _, _, _, _, sockaddr in resolved:
+                ip_str = sockaddr[0]
+                try:
+                    addr = ipaddress.ip_address(ip_str)
+                    if addr.is_private or addr.is_reserved or addr.is_loopback or addr.is_link_local:
+                        if verbose:
+                            logger.warning(
+                                "BLOCKED: '%s' resolves to private IP %s",
+                                _safe_log_value(hostname),
+                                addr,
+                            )
+                        return False
+                except ValueError:
+                    continue
+        except (socket.gaierror, OSError) as exc:
+            if verbose:
+                logger.debug("DNS resolution failed for '%s': %s", _safe_log_value(hostname), exc)
+
+    return True
+
+
+def sanitize_content(text: str) -> str:
+    """Run fetched content through the scrubber pipeline."""
+    if not text:
+        return text
+
+    result = scrub_content(text)
+    if result.threats:
+        threat_types = {threat.threat_type.value for threat in result.threats}
+        logger.info(
+            "Scrubber: %s threats detected (types=%s, risk=%.2f, redactions=%s)",
+            len(result.threats),
+            threat_types,
+            result.risk_score,
+            result.redactions,
+        )
+    return result.content
+
+
+def clean_html(html: str, parser: str = "html.parser") -> Optional[str]:
+    """Extract readable text from HTML with smart content detection."""
+    soup = BeautifulSoup(html, parser)
+
+    for tag in soup(GARBAGE_TAGS):
+        tag.decompose()
+
+    for selector in GARBAGE_CLASSES:
+        for el in soup.select(selector):
+            el.decompose()
+
+    for selector in CONTENT_SELECTORS:
+        el = soup.select_one(selector)
+        if el:
+            text = el.get_text(separator="\n", strip=True)
+            if len(text) >= MIN_USEFUL_CHARS:
+                return text[:MAX_CONTENT_CHARS]
+
+    text = soup.get_text(separator="\n", strip=True)
+    return text[:MAX_CONTENT_CHARS] if len(text) >= MIN_USEFUL_CHARS else None

--- a/app/killchain.py
+++ b/app/killchain.py
@@ -810,6 +810,29 @@ async def strategy_youtube(url: str) -> Optional[str]:
     return await loop.run_in_executor(None, strategy_youtube_sync, url)
 
 
+async def strategy_browser_render(url: str, max_chars: int | None = None) -> Optional[str]:
+    """Browser-rendered extraction for JS-rendered pages.
+
+    This renderer does not solve challenges or bypass blocked search engines.
+    It returns content only when an ephemeral browser context can render useful
+    page text without hitting a CAPTCHA/challenge page.
+    """
+    try:
+        from app.browser_renderer import render_browser_page
+
+        result = await render_browser_page(url, max_chars=max_chars or MAX_CONTENT_CHARS)
+        if result.success and result.content:
+            return result.content
+        if result.challenge_detected:
+            logger.info("Browser render detected challenge for %s", _safe_log_value(_hostname(url)))
+        elif result.error:
+            logger.debug("Browser render failed for %s: %s", _safe_log_value(_hostname(url)), result.error)
+        return None
+    except Exception as exc:
+        logger.debug("Browser render strategy failed for %s: %s", _safe_log_value(_hostname(url)), exc)
+        return None
+
+
 # ---------------------------------------------------------------------------
 # The Kill Chain
 # ---------------------------------------------------------------------------
@@ -971,6 +994,7 @@ async def kill_chain(
         ("direct", lambda: strategy_direct(client, url)),
         ("readability", lambda: strategy_readability(client, url)),
         ("ua-rotate", lambda: strategy_ua_rotation(client, url)),
+        ("browser-render", lambda: strategy_browser_render(url, effective_max)),
     ]
 
     # If Cloudflare detected for this domain, insert CF adapter before wayback/cache

--- a/app/main.py
+++ b/app/main.py
@@ -53,6 +53,7 @@ from app.models import (
     AdaptStatsResponse,
     BatchReadRequest,
     BatchReadResponse,
+    BrowserFetchResponse,
     EngineInfo,
     EvolveResponse,
     HealthResponse,
@@ -1321,6 +1322,19 @@ async def search_stats() -> SearchStats:
     )
 
 
+def _trust_info(trust) -> TrustInfo | None:
+    if not trust:
+        return None
+    return TrustInfo(
+        domain=trust.domain,
+        tier=trust.tier,
+        score=trust.score,
+        reasons=trust.reasons,
+        https=trust.https,
+        lookalike_of=trust.lookalike_of,
+    )
+
+
 # =========================================================================
 # READ ENDPOINTS (Kill Chain)
 # =========================================================================
@@ -1333,8 +1347,8 @@ async def read_url(
 ) -> ReadResponse:
     """Extract readable content from a URL using the kill chain.
 
-    Tries 9 strategies in escalating order: direct fetch, readability,
-    UA rotation, Wayback Machine, Google Cache, search-about, custom
+    Tries escalating strategies: direct fetch, readability, UA rotation,
+    browser rendering, Wayback Machine, Google Cache, search-about, custom
     adapters, PDF extraction, and YouTube transcripts.
     """
     assert http_client is not None
@@ -1354,14 +1368,6 @@ async def read_url(
             result.chars, result.strategies_tried, result.error,
         )
 
-    trust_info = None
-    if result.trust:
-        trust_info = TrustInfo(
-            domain=result.trust.domain, tier=result.trust.tier,
-            score=result.trust.score, reasons=result.trust.reasons,
-            https=result.trust.https, lookalike_of=result.trust.lookalike_of,
-        )
-
     return ReadResponse(
         url=result.url,
         content=result.content,
@@ -1371,7 +1377,51 @@ async def read_url(
         strategies_tried=result.strategies_tried,
         error=result.error,
         success=result.success,
-        trust=trust_info,
+        trust=_trust_info(result.trust),
+    )
+
+
+@app.get("/providers/browser/fetch", response_model=BrowserFetchResponse)
+async def browser_fetch(
+    url: str = Query(..., description="URL to render and extract"),
+    max_chars: int | None = Query(None, ge=200, le=50000, description="Max content length"),
+    max_links: int | None = Query(None, ge=0, le=200, description="Max rendered links to return"),
+    timeout_ms: int | None = Query(None, ge=1000, le=60000, description="Browser render timeout in milliseconds"),
+) -> BrowserFetchResponse:
+    """Render a safe page in an ephemeral browser context and extract text/links."""
+    from app.browser_renderer import render_browser_page
+
+    result = await render_browser_page(
+        url,
+        max_chars=max_chars,
+        max_links=max_links,
+        timeout_ms=timeout_ms,
+    )
+    if content_cache and result.success and result.content:
+        await content_cache.set(result.final_url or result.url, result.content, result.strategy)
+        await content_cache.log_fetch(
+            result.final_url or result.url,
+            result.strategy,
+            result.success,
+            result.chars,
+            [result.strategy],
+            result.error,
+        )
+
+    return BrowserFetchResponse(
+        url=result.url,
+        final_url=result.final_url,
+        title=result.title,
+        content=result.content,
+        chars=result.chars,
+        links=[{"text": link.text, "url": link.url} for link in result.links],
+        success=result.success,
+        strategy=result.strategy,
+        error=result.error,
+        challenge_detected=result.challenge_detected,
+        blocked_reason=result.blocked_reason,
+        render_time_ms=result.render_time_ms,
+        trust=_trust_info(result.trust),
     )
 
 
@@ -1407,11 +1457,7 @@ async def read_batch(body: BatchReadRequest) -> BatchReadResponse:
             strategies_tried=r.strategies_tried,
             error=r.error,
             success=r.success,
-            trust=TrustInfo(
-                domain=r.trust.domain, tier=r.trust.tier,
-                score=r.trust.score, reasons=r.trust.reasons,
-                https=r.trust.https, lookalike_of=r.trust.lookalike_of,
-            ) if r.trust else None,
+            trust=_trust_info(r.trust),
         )
         for r in results
     ]

--- a/app/models.py
+++ b/app/models.py
@@ -90,6 +90,31 @@ class BatchReadResponse(BaseModel):
     failed: int
 
 
+class BrowserLink(BaseModel):
+    """Link extracted from a rendered page."""
+
+    text: str
+    url: str
+
+
+class BrowserFetchResponse(BaseModel):
+    """Response from /providers/browser/fetch."""
+
+    url: str
+    final_url: str = ""
+    title: str = ""
+    content: str | None = Field(None, description="Extracted rendered text")
+    chars: int = 0
+    links: list[BrowserLink] = Field(default_factory=list)
+    success: bool = False
+    strategy: str = "browser-render"
+    error: str | None = None
+    challenge_detected: bool = False
+    blocked_reason: str | None = None
+    render_time_ms: float = 0.0
+    trust: TrustInfo | None = Field(None, description="Domain trust assessment")
+
+
 # ---------------------------------------------------------------------------
 # News
 # ---------------------------------------------------------------------------

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -8,14 +8,14 @@
 
 MCP tool server that gives AI agents access to the engines enabled in your connected SearXNG-backed AgentSearch instance. Self-hosted. No third-party search API keys required; optional local bearer auth is supported.
 
-Built on [AgentSearch](https://github.com/brcrusoe72/agent-search), which wraps SearXNG with multi-engine fusion, a 9-strategy content extraction kill chain, news aggregation, and job search.
+Built on [AgentSearch](https://github.com/brcrusoe72/agent-search), which wraps SearXNG with multi-engine fusion, kill-chain content extraction, browser-rendered extraction, news aggregation, and job search.
 
 ## Why AgentSearch?
 
 | Feature | AgentSearch | Other search MCP servers |
 |---------|-------------|-------------------------|
 | Search engines | SearXNG-backed; run `/engines` for the live list | Usually 1-3 |
-| Content extraction | 9-strategy kill chain (handles paywalls, Cloudflare, etc.) | Basic fetch or none |
+| Content extraction | Kill chain plus browser-render extraction | Basic fetch or none |
 | Multi-query fusion | ✓ (generates 3-5 query variations) | ✗ |
 | News aggregation | News engines enabled in SearXNG | ✗ |
 | Job search | Dedicated job board search | ✗ |
@@ -37,7 +37,8 @@ Built on [AgentSearch](https://github.com/brcrusoe72/agent-search), which wraps 
 | `policy_search` | Policy/geopolitical search with source-library and domain-quality ranking |
 | `source_search` | Trace primary sources across curated institutions |
 | `source_institutions` | List curated source registry institutions |
-| `read_url` | Extract content from any URL using a 9-strategy kill chain |
+| `read_url` | Extract content from any URL using the kill chain |
+| `browser_fetch` | Render a safe target URL in an ephemeral browser context and extract text/links |
 | `read_batch` | Batch extract content from up to 20 URLs concurrently |
 | `news` | Structured news search using enabled or explicitly selected SearXNG news engines |
 | `search_jobs` | Job board search with location and salary filters |
@@ -140,19 +141,22 @@ The server uses **stdio transport**. Launch `python server.py` as a subprocess a
 
 ## How the Kill Chain Works
 
-When extracting content from a URL, AgentSearch tries up to 9 strategies in sequence:
+When extracting content from a URL, AgentSearch tries escalating strategies in sequence:
 
 1. **Direct fetch** — simple HTTP GET
 2. **Readability extraction** — strip boilerplate, extract article
 3. **User-Agent rotation** — try different browser signatures
-4. **Wayback Machine** — fetch cached version from Internet Archive
-5. **Google Cache** — fetch Google's cached copy
-6. **Search-about** — find the content via search engines
-7. **Custom adapters** — site-specific extractors
-8. **PDF extraction** — for PDF URLs
-9. **YouTube transcript** — for YouTube URLs
+4. **Browser render** — render JS-heavy target pages in an ephemeral context
+5. **Wayback Machine** — fetch cached version from Internet Archive
+6. **Google Cache** — fetch Google's cached copy
+7. **Search-about** — find the content via search engines
+8. **Custom adapters** — site-specific extractors
+9. **PDF extraction** — for PDF URLs
+10. **YouTube transcript** — for YouTube URLs
 
 Each strategy is tried until one succeeds. The Evolver system tracks success rates by domain and strategy, learning which approaches work for which sites.
+
+The `browser_fetch` MCP tool exposes the browser renderer directly. It extracts rendered text and links from safe target pages, and reports CAPTCHA/challenge pages instead of trying to bypass them.
 
 ## Architecture
 

--- a/mcp-server/agent_search_mcp/server.py
+++ b/mcp-server/agent_search_mcp/server.py
@@ -168,13 +168,27 @@ def make_server(base_url: str, token: str | None = None) -> Server:
             ),
             Tool(
                 name="read_url",
-                description="Extract readable content from any URL using a 9-strategy kill chain (direct, readability, UA rotation, Wayback, Google Cache, etc).",
+                description="Extract readable content from any URL using the kill chain, including direct fetch, readability, UA rotation, browser render, Wayback, cache, adapters, PDF, and YouTube.",
                 inputSchema={
                     "type": "object",
                     "properties": {
                         "url": {"type": "string", "description": "URL to extract content from"},
                         "max_chars": {"type": "integer", "description": "Maximum content length"},
                         "skip_cache": {"type": "boolean", "description": "Bypass content cache", "default": False},
+                    },
+                    "required": ["url"],
+                },
+            ),
+            Tool(
+                name="browser_fetch",
+                description="Render a safe URL in an ephemeral browser context and extract readable text/links. Reports challenges instead of bypassing them.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string", "description": "URL to render and extract"},
+                        "max_chars": {"type": "integer", "description": "Maximum extracted content length"},
+                        "max_links": {"type": "integer", "description": "Maximum rendered links to return"},
+                        "timeout_ms": {"type": "integer", "description": "Browser render timeout in milliseconds"},
                     },
                     "required": ["url"],
                 },
@@ -284,6 +298,11 @@ def make_server(base_url: str, token: str | None = None) -> Server:
                     if arguments.get("skip_cache"):
                         params["skip_cache"] = "true"
                     r = await client.get("/read", params=params)
+
+                elif name == "browser_fetch":
+                    params = {"url": arguments["url"]}
+                    _add_optional(params, arguments, "max_chars", "max_links", "timeout_ms")
+                    r = await client.get("/providers/browser/fetch", params=params)
 
                 elif name == "read_batch":
                     body = {"urls": arguments["urls"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "beautifulsoup4==4.12.2",
     "pdfplumber>=0.11.4,<0.12",
     "lxml==6.1.0",
+    "playwright>=1.50,<2",
     "requests[socks]==2.33.0",
     "yt-dlp>=2025.3.31",
     "python-whois>=0.9.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ lxml==6.1.0
 requests[socks]==2.33.0
 yt-dlp>=2025.3.31
 python-whois>=0.9.4
+playwright>=1.50,<2

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -122,12 +122,25 @@ results = client.search_policy("South China Sea maritime disputes", fetch=True)
 
 ### `client.read(url, *, max_chars=None, skip_cache=False)`
 
-Extract readable content from any URL using 9 escalating strategies (direct → readability → UA rotation → Wayback Machine → Google Cache → search-about → custom adapters → PDF → YouTube).
+Extract readable content from any URL using escalating strategies (direct -> readability -> UA rotation -> browser render -> Wayback Machine -> Google Cache -> search-about -> custom adapters -> PDF -> YouTube).
 
 ```python
 content = client.read("https://example.com/article")
 print(content.content)
 print(f"Strategy: {content.strategy}, Chars: {content.chars}")
+```
+
+---
+
+### `client.browser_fetch(url, *, max_chars=None, max_links=None, timeout_ms=None)`
+
+Render a safe target URL in an ephemeral browser context and extract readable text plus links. This is for JS-rendered pages; CAPTCHA/challenge pages are reported, not bypassed.
+
+```python
+rendered = client.browser_fetch("https://example.com/app", max_links=20)
+print(rendered.title)
+print(rendered.content)
+print(rendered.links[:3])
 ```
 
 ---

--- a/sdk/agentsearch/__init__.py
+++ b/sdk/agentsearch/__init__.py
@@ -17,6 +17,8 @@ Or use module-level convenience functions::
 from .client import AgentSearch, AgentSearchError
 from .models import (
     BatchReadResponse,
+    BrowserFetchResponse,
+    BrowserLink,
     HealthResponse,
     JobResult,
     JobSearchResponse,
@@ -37,6 +39,8 @@ __all__ = [
     "SearchMeta",
     "ReadResult",
     "BatchReadResponse",
+    "BrowserLink",
+    "BrowserFetchResponse",
     "NewsResult",
     "NewsResponse",
     "JobResult",
@@ -48,6 +52,7 @@ __all__ = [
     "deep_search",
     "read",
     "read_batch",
+    "browser_fetch",
     "news",
     "search_jobs",
 ]
@@ -102,6 +107,11 @@ def read(url: str, **kwargs) -> ReadResult:  # type: ignore[no-untyped-def]
 def read_batch(urls: list, **kwargs) -> BatchReadResponse:  # type: ignore[no-untyped-def]
     """Extract content from multiple URLs. See :meth:`AgentSearch.read_batch`."""
     return _get_client().read_batch(urls, **kwargs)
+
+
+def browser_fetch(url: str, **kwargs) -> BrowserFetchResponse:  # type: ignore[no-untyped-def]
+    """Browser-render a URL. See :meth:`AgentSearch.browser_fetch`."""
+    return _get_client().browser_fetch(url, **kwargs)
 
 
 def news(query: str, **kwargs) -> NewsResponse:  # type: ignore[no-untyped-def]

--- a/sdk/agentsearch/client.py
+++ b/sdk/agentsearch/client.py
@@ -12,6 +12,8 @@ from urllib.request import Request, urlopen
 
 from .models import (
     BatchReadResponse,
+    BrowserFetchResponse,
+    BrowserLink,
     HealthResponse,
     JobResult,
     JobSearchResponse,
@@ -237,6 +239,27 @@ class AgentSearch:
         )
 
     @staticmethod
+    def _parse_browser_fetch_response(d: Dict[str, Any]) -> BrowserFetchResponse:
+        return BrowserFetchResponse(
+            url=d.get("url", ""),
+            final_url=d.get("final_url", ""),
+            title=d.get("title", ""),
+            content=d.get("content"),
+            chars=d.get("chars", 0),
+            links=[
+                BrowserLink(text=item.get("text", ""), url=item.get("url", ""))
+                for item in d.get("links", [])
+                if isinstance(item, dict)
+            ],
+            success=d.get("success", False),
+            strategy=d.get("strategy", "browser-render"),
+            error=d.get("error"),
+            challenge_detected=d.get("challenge_detected", False),
+            blocked_reason=d.get("blocked_reason"),
+            render_time_ms=d.get("render_time_ms", 0.0),
+        )
+
+    @staticmethod
     def _parse_news_result(d: Dict[str, Any]) -> NewsResult:
         return NewsResult(
             title=d.get("title", ""),
@@ -421,9 +444,9 @@ class AgentSearch:
     ) -> ReadResult:
         """Extract readable content from a URL using the kill chain.
 
-        Tries 9 strategies in escalating order: direct fetch, readability,
-        UA rotation, Wayback Machine, Google Cache, search-about, custom
-        adapters, PDF extraction, and YouTube transcripts.
+        Tries escalating strategies: direct fetch, readability, UA rotation,
+        browser rendering, Wayback Machine, Google Cache, search-about,
+        custom adapters, PDF extraction, and YouTube transcripts.
 
         Args:
             url: URL to extract content from.
@@ -468,6 +491,30 @@ class AgentSearch:
             successful=data.get("successful", 0),
             failed=data.get("failed", 0),
         )
+
+    def browser_fetch(
+        self,
+        url: str,
+        *,
+        max_chars: Optional[int] = None,
+        max_links: Optional[int] = None,
+        timeout_ms: Optional[int] = None,
+    ) -> BrowserFetchResponse:
+        """Render a URL in an ephemeral browser context and extract text/links.
+
+        This endpoint is for JS-rendered target pages. It reports CAPTCHA or
+        challenge pages as blocked instead of trying to bypass them.
+        """
+        params: Dict[str, Any] = {"url": url}
+        if max_chars is not None:
+            params["max_chars"] = max_chars
+        if max_links is not None:
+            params["max_links"] = max_links
+        if timeout_ms is not None:
+            params["timeout_ms"] = timeout_ms
+
+        data = self._get("/providers/browser/fetch", params)
+        return self._parse_browser_fetch_response(data)
 
     def news(
         self,

--- a/sdk/agentsearch/models.py
+++ b/sdk/agentsearch/models.py
@@ -70,6 +70,32 @@ class BatchReadResponse:
 
 
 @dataclass
+class BrowserLink:
+    """Link extracted from a rendered page."""
+
+    text: str = ""
+    url: str = ""
+
+
+@dataclass
+class BrowserFetchResponse:
+    """Response from browser-render extraction."""
+
+    url: str = ""
+    final_url: str = ""
+    title: str = ""
+    content: Optional[str] = None
+    chars: int = 0
+    links: List[BrowserLink] = field(default_factory=list)
+    success: bool = False
+    strategy: str = "browser-render"
+    error: Optional[str] = None
+    challenge_detected: bool = False
+    blocked_reason: Optional[str] = None
+    render_time_ms: float = 0.0
+
+
+@dataclass
 class NewsResult:
     """A structured news result."""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -862,6 +862,80 @@ def test_browser_render_ignores_close_errors(monkeypatch: pytest.MonkeyPatch) ->
     assert result.links[0].url == "https://example.com/docs"
 
 
+def test_browser_render_rejects_http_error_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeLocator:
+        async def inner_text(self, timeout: int) -> str:
+            return "Rendered error page content " * 20
+
+    class FakePage:
+        url = "https://example.com/missing"
+
+        async def route(self, pattern: str, handler) -> None:
+            return None
+
+        async def goto(self, url: str, wait_until: str, timeout: int):
+            self.url = url
+            return types.SimpleNamespace(status=404)
+
+        async def wait_for_load_state(self, state: str, timeout: int) -> None:
+            return None
+
+        async def title(self) -> str:
+            return "Not Found"
+
+        async def content(self) -> str:
+            return "<html><body><main>Rendered error page content " * 20 + "</main></body></html>"
+
+        def locator(self, selector: str) -> FakeLocator:
+            return FakeLocator()
+
+    class FakeContext:
+        async def new_page(self) -> FakePage:
+            return FakePage()
+
+        async def close(self) -> None:
+            return None
+
+    class FakeBrowser:
+        async def new_context(self, **kwargs) -> FakeContext:
+            return FakeContext()
+
+        async def close(self) -> None:
+            return None
+
+    class FakeChromium:
+        async def launch(self, **kwargs) -> FakeBrowser:
+            return FakeBrowser()
+
+    class FakePlaywright:
+        chromium = FakeChromium()
+
+    class FakePlaywrightManager:
+        async def __aenter__(self) -> FakePlaywright:
+            return FakePlaywright()
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    fake_async_api = types.ModuleType("playwright.async_api")
+    fake_async_api.TimeoutError = TimeoutError
+    fake_async_api.async_playwright = lambda: FakePlaywrightManager()
+    fake_playwright = types.ModuleType("playwright")
+    fake_playwright.async_api = fake_async_api
+
+    monkeypatch.setitem(sys.modules, "playwright", fake_playwright)
+    monkeypatch.setitem(sys.modules, "playwright.async_api", fake_async_api)
+    monkeypatch.setattr(browser_renderer, "is_safe_url", lambda url, verbose=False: True)
+    monkeypatch.setattr(browser_renderer, "_default_chromium_path", lambda: "/usr/bin/chromium")
+
+    result = asyncio.run(browser_renderer.render_browser_page("https://example.com/missing"))
+
+    assert result.success is False
+    assert result.content is None
+    assert result.blocked_reason == "http_error"
+    assert result.error == "Rendered navigation returned HTTP 404"
+
+
 def test_strategy_coverage_preserves_successful_provider_rows() -> None:
     def result(title: str, url: str, engine: str, position: int) -> main.SearchResult:
         return main.SearchResult(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,12 +11,15 @@ from __future__ import annotations
 import asyncio
 import os
 import socket
+import sys
+import types
 
 import httpx
 import pytest
 
 from app import killchain
 from app import main
+from app import browser_renderer
 from app.cache import Cache
 from app.database import QueryDatabase
 from app.dedup import deduplicate_with_scoring
@@ -733,6 +736,130 @@ def test_news_records_searxng_error_attempt(monkeypatch: pytest.MonkeyPatch, cli
     assert row["errors"] == 1
     assert row["health"] == "error"
     assert "SearXNG error" in row["last_error"]
+
+
+def test_browser_challenge_detection() -> None:
+    assert browser_renderer.detect_browser_challenge("Client Challenge", "Verify you are human", "")
+    assert browser_renderer.detect_browser_challenge("Access denied", "Cloudflare Ray ID: abc", "")
+    assert not browser_renderer.detect_browser_challenge("Example Domain", "Ordinary article content", "")
+
+
+def test_browser_extract_rendered_content() -> None:
+    paragraph = "Rendered application text with enough useful content for extraction. " * 8
+    html = f"<html><body><main><p>{paragraph}</p></main></body></html>"
+
+    content = browser_renderer.extract_rendered_content(html, "", 1000)
+
+    assert content is not None
+    assert "Rendered application text" in content
+
+
+def test_browser_fetch_endpoint(monkeypatch: pytest.MonkeyPatch, client: AppClient) -> None:
+    async def fake_render_browser_page(url: str, **kwargs):
+        return browser_renderer.BrowserRenderResult(
+            url=url,
+            final_url=url,
+            title="Rendered App",
+            content="Rendered app content " * 20,
+            chars=420,
+            links=[
+                browser_renderer.BrowserLink(text="Docs", url="https://example.com/docs"),
+            ],
+            success=True,
+            render_time_ms=12.3,
+        )
+
+    monkeypatch.setattr(browser_renderer, "render_browser_page", fake_render_browser_page)
+
+    response = client.get(
+        "/providers/browser/fetch",
+        params={"url": "https://example.com/app", "max_chars": 1000, "max_links": 5},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["strategy"] == "browser-render"
+    assert data["title"] == "Rendered App"
+    assert data["links"] == [{"text": "Docs", "url": "https://example.com/docs"}]
+
+
+def test_browser_render_ignores_close_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeLocator:
+        async def inner_text(self, timeout: int) -> str:
+            return "Rendered body content " * 20
+
+    class FakePage:
+        url = "https://example.com/app"
+
+        async def route(self, pattern: str, handler) -> None:
+            return None
+
+        async def goto(self, url: str, wait_until: str, timeout: int):
+            self.url = url
+            return types.SimpleNamespace(status=200)
+
+        async def wait_for_load_state(self, state: str, timeout: int) -> None:
+            return None
+
+        async def title(self) -> str:
+            return "Example App"
+
+        async def content(self) -> str:
+            body = "Rendered body content " * 20
+            return f"<html><body><main><p>{body}</p></main><a href='https://example.com/docs'>Docs</a></body></html>"
+
+        def locator(self, selector: str) -> FakeLocator:
+            return FakeLocator()
+
+        async def evaluate(self, script: str, max_links: int):
+            return [{"text": "Docs", "href": "https://example.com/docs"}]
+
+    class FakeContext:
+        async def new_page(self) -> FakePage:
+            return FakePage()
+
+        async def close(self) -> None:
+            raise RuntimeError("context already closed")
+
+    class FakeBrowser:
+        async def new_context(self, **kwargs) -> FakeContext:
+            return FakeContext()
+
+        async def close(self) -> None:
+            raise RuntimeError("browser already closed")
+
+    class FakeChromium:
+        async def launch(self, **kwargs) -> FakeBrowser:
+            return FakeBrowser()
+
+    class FakePlaywright:
+        chromium = FakeChromium()
+
+    class FakePlaywrightManager:
+        async def __aenter__(self) -> FakePlaywright:
+            return FakePlaywright()
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    fake_async_api = types.ModuleType("playwright.async_api")
+    fake_async_api.TimeoutError = TimeoutError
+    fake_async_api.async_playwright = lambda: FakePlaywrightManager()
+    fake_playwright = types.ModuleType("playwright")
+    fake_playwright.async_api = fake_async_api
+
+    monkeypatch.setitem(sys.modules, "playwright", fake_playwright)
+    monkeypatch.setitem(sys.modules, "playwright.async_api", fake_async_api)
+    monkeypatch.setattr(browser_renderer, "is_safe_url", lambda url, verbose=False: True)
+    monkeypatch.setattr(browser_renderer, "_default_chromium_path", lambda: "/usr/bin/chromium")
+
+    result = asyncio.run(browser_renderer.render_browser_page("https://example.com/app", max_links=5))
+
+    assert result.success is True
+    assert result.title == "Example App"
+    assert result.content and "Rendered body content" in result.content
+    assert result.links[0].url == "https://example.com/docs"
 
 
 def test_strategy_coverage_preserves_successful_provider_rows() -> None:

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -34,3 +34,32 @@ def test_sdk_loads_token_from_local_credentials_file(monkeypatch, tmp_path) -> N
     assert client.token == "file-token"
     assert client._headers()["Authorization"] == "Bearer file-token"
     client.close()
+
+
+def test_sdk_browser_fetch_parses_response(monkeypatch) -> None:
+    client = AgentSearch(token="token")
+
+    def fake_get(path, params):
+        assert path == "/providers/browser/fetch"
+        assert params["url"] == "https://example.com/app"
+        return {
+            "url": "https://example.com/app",
+            "final_url": "https://example.com/app",
+            "title": "Rendered App",
+            "content": "Rendered content",
+            "chars": 16,
+            "links": [{"text": "Docs", "url": "https://example.com/docs"}],
+            "success": True,
+            "strategy": "browser-render",
+            "challenge_detected": False,
+            "render_time_ms": 12.3,
+        }
+
+    monkeypatch.setattr(client, "_get", fake_get)
+
+    result = client.browser_fetch("https://example.com/app", max_links=5)
+
+    assert result.success is True
+    assert result.title == "Rendered App"
+    assert result.links[0].url == "https://example.com/docs"
+    client.close()


### PR DESCRIPTION
## What changed

Adds a bounded browser-render extraction provider to AgentSearch:

- new `/providers/browser/fetch` API endpoint
- browser-render step in the URL read kill chain
- SDK and MCP `browser_fetch` support
- Chromium and Playwright runtime dependency in the API image
- docs for the endpoint, SDK, MCP tool, and guardrails

## Guardrails

The browser layer is a renderer/extractor, not a search-engine bypass tool. It uses an ephemeral browser context, blocks unsafe URLs and private-address redirects, blocks direct search-engine domains by default, detects challenge/block pages, and avoids login/profile/CAPTCHA behavior.

## Validation

- `python3 -m pytest -q` -> `59 passed, 10 skipped`
- `python3 -m compileall app adapters mcp-server/agent_search_mcp scripts sdk -q`
- Docker rebuild completed for `agent-search_api` and `agent-search_api-private`
- `/health` on `127.0.0.1:3939` and `127.0.0.1:3940` -> healthy
- live browser fetch `https://www.python.org/about/` -> success, 1200 chars, 5 links, no challenge
- live JS render fetch `https://quotes.toscrape.com/js/` -> success, content included rendered quote text
- live Google search URL fetch -> blocked with `Browser rendering disabled for search-engine domain 'google.com'`
- Docker live integration: `AGENTSEARCH_DOCKER_INTEGRATION=1 python3 -m pytest tests/test_live_docker.py -q` -> `9 passed`
