### PR TITLE
[codex] Add SQLite retention maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,10 @@ Environment variables (set in `docker-compose.yml` or `.env`):
 | `CACHE_TTL` | `3600` | Cache duration in seconds |
 | `RATE_LIMIT` | `60` | Max requests per minute |
 | `SQLITE_TIMEOUT` | `1.0` | SQLite lock wait timeout in seconds for query stats |
+| `FETCH_LOG_RETENTION_DAYS` | `30` | Delete fetch analytics rows older than this many days during SQLite maintenance |
+| `QUERY_LOG_RETENTION_DAYS` | `30` | Delete query analytics rows older than this many days during SQLite maintenance |
+| `SQLITE_MAINTENANCE_INTERVAL_SECONDS` | `3600` | Interval for expired content-cache cleanup, log retention, and `PRAGMA optimize` |
+| `SQLITE_VACUUM_MIN_DELETED_ROWS` | `1000` | Run `VACUUM` only when a maintenance pass deletes at least this many rows; set `0` to disable threshold vacuum |
 | `AGENT_SEARCH_TOKEN` | *(empty)* | Bearer token for auth (optional) |
 | `ADAPTERS_DIR` | `/app/adapters` | Path to pluggable adapter modules |
 

--- a/app/content_cache.py
+++ b/app/content_cache.py
@@ -23,6 +23,8 @@ DEFAULT_TTL = 86400       # 24 hours for articles
 NEWS_TTL = 3600           # 1 hour for news
 YOUTUBE_TTL = 604800      # 7 days for YouTube transcripts
 PDF_TTL = 604800          # 7 days for PDFs
+FETCH_LOG_RETENTION_DAYS = int(os.getenv("FETCH_LOG_RETENTION_DAYS", "30"))
+SQLITE_VACUUM_MIN_DELETED_ROWS = int(os.getenv("SQLITE_VACUUM_MIN_DELETED_ROWS", "1000"))
 
 # Strategy → TTL mapping
 STRATEGY_TTL = {
@@ -229,15 +231,55 @@ class ContentCache:
 
     async def evict_expired(self) -> int:
         """Remove expired cache entries. Returns count removed."""
-        def _evict():
-            with sqlite3.connect(self.db_path) as conn:
-                cursor = conn.execute(
-                    "DELETE FROM content_cache WHERE expires_at < ?", (time.time(),)
-                )
-                conn.commit()
-                return cursor.rowcount
-
-        loop = asyncio.get_event_loop()
-        count = await loop.run_in_executor(None, _evict)
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                "DELETE FROM content_cache WHERE expires_at < ?", (time.time(),)
+            )
+            conn.commit()
+            count = cursor.rowcount
         self._stats["evictions"] += count
         return count
+
+    def maintain(
+        self,
+        *,
+        fetch_log_retention_days: int = FETCH_LOG_RETENTION_DAYS,
+        vacuum_min_deleted_rows: int = SQLITE_VACUUM_MIN_DELETED_ROWS,
+    ) -> dict:
+        """Prune expired cache and old fetch logs, then optimize SQLite."""
+        retention_seconds = max(fetch_log_retention_days, 0) * 86400
+
+        now = time.time()
+        fetch_cutoff = now - retention_seconds
+        conn = sqlite3.connect(self.db_path)
+        try:
+            expired_cursor = conn.execute(
+                "DELETE FROM content_cache WHERE expires_at < ?", (now,)
+            )
+            expired_cache = max(expired_cursor.rowcount, 0)
+
+            fetch_cursor = conn.execute(
+                "DELETE FROM fetch_log WHERE timestamp < ?", (fetch_cutoff,)
+            )
+            old_fetch_logs = max(fetch_cursor.rowcount, 0)
+            conn.commit()
+
+            conn.execute("PRAGMA optimize")
+            conn.commit()
+
+            deleted_rows = expired_cache + old_fetch_logs
+            vacuumed = deleted_rows >= vacuum_min_deleted_rows > 0
+            if vacuumed:
+                conn.execute("VACUUM")
+
+            result = {
+                "expired_content_cache": expired_cache,
+                "old_fetch_logs": old_fetch_logs,
+                "deleted_rows": deleted_rows,
+                "fetch_log_retention_days": fetch_log_retention_days,
+                "vacuumed": vacuumed,
+            }
+        finally:
+            conn.close()
+        self._stats["evictions"] += result["expired_content_cache"]
+        return result

--- a/app/database.py
+++ b/app/database.py
@@ -9,6 +9,9 @@ from typing import Dict, List
 
 logger = logging.getLogger("agentsearch.database")
 
+QUERY_LOG_RETENTION_DAYS = int(os.getenv("QUERY_LOG_RETENTION_DAYS", "30"))
+SQLITE_VACUUM_MIN_DELETED_ROWS = int(os.getenv("SQLITE_VACUUM_MIN_DELETED_ROWS", "1000"))
+
 
 class QueryDatabase:
     """Simple SQLite database for tracking queries and engine performance."""
@@ -116,6 +119,62 @@ class QueryDatabase:
                 'queries_per_engine': engine_counts,
                 'avg_results_per_engine': avg_results
             }
+
+    def maintain(
+        self,
+        *,
+        query_log_retention_days: int = QUERY_LOG_RETENTION_DAYS,
+        vacuum_min_deleted_rows: int = SQLITE_VACUUM_MIN_DELETED_ROWS,
+    ) -> Dict:
+        """Prune old query logs, then optimize SQLite."""
+        if self.disabled:
+            return {
+                "old_query_logs": 0,
+                "deleted_rows": 0,
+                "query_log_retention_days": query_log_retention_days,
+                "vacuumed": False,
+                "disabled": True,
+            }
+
+        retention_seconds = max(query_log_retention_days, 0) * 86400
+
+        try:
+            cutoff = time.time() - retention_seconds
+            conn = self._connect()
+            try:
+                cursor = conn.execute(
+                    "DELETE FROM query_log WHERE timestamp < ?", (cutoff,)
+                )
+                old_query_logs = max(cursor.rowcount, 0)
+                conn.commit()
+
+                conn.execute("PRAGMA optimize")
+                conn.commit()
+
+                vacuumed = old_query_logs >= vacuum_min_deleted_rows > 0
+                if vacuumed:
+                    conn.execute("VACUUM")
+
+                return {
+                    "old_query_logs": old_query_logs,
+                    "deleted_rows": old_query_logs,
+                    "query_log_retention_days": query_log_retention_days,
+                    "vacuumed": vacuumed,
+                    "disabled": False,
+                }
+            finally:
+                conn.close()
+        except sqlite3.OperationalError as exc:
+            if "readonly" in str(exc).lower():
+                self.disabled = True
+                return {
+                    "old_query_logs": 0,
+                    "deleted_rows": 0,
+                    "query_log_retention_days": query_log_retention_days,
+                    "vacuumed": False,
+                    "disabled": True,
+                }
+            raise
 
 
 # Global instance

--- a/app/main.py
+++ b/app/main.py
@@ -29,6 +29,7 @@ import re
 import time
 import asyncio
 import secrets
+import threading
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -77,6 +78,7 @@ VERSION = "2.0.0"
 HEALTHCHECK_QUERY = os.getenv("HEALTHCHECK_QUERY", "python programming language")
 HEALTHCHECK_ENGINES = os.getenv("HEALTHCHECK_ENGINES", "github")
 HEALTHCHECK_SEARCH_TIMEOUT = float(os.getenv("HEALTHCHECK_SEARCH_TIMEOUT", "15"))
+SQLITE_MAINTENANCE_INTERVAL_SECONDS = max(1, int(os.getenv("SQLITE_MAINTENANCE_INTERVAL_SECONDS", "3600")))
 
 # Request logging
 logging.basicConfig(
@@ -110,23 +112,47 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     if evolver is None:
         evolver = Evolver()
 
-    # Periodic cache eviction (every hour)
-    async def _evict_loop():
-        while True:
-            await asyncio.sleep(3600)
-            try:
-                assert content_cache is not None
-                count = await content_cache.evict_expired()
-                if count > 0:
-                    logger.info("Evicted %s expired cache entries", count)
-            except Exception as exc:
-                logger.debug("Cache eviction failed: %s", exc)
+    maintenance_lock = threading.Lock()
 
-    evict_task = asyncio.create_task(_evict_loop())
+    def _run_sqlite_maintenance() -> None:
+        if not maintenance_lock.acquire(blocking=False):
+            logger.debug("Skipping SQLite maintenance because previous pass is still running")
+            return
+        try:
+            assert content_cache is not None
+            cache_result = content_cache.maintain()
+            query_result = query_db.maintain()
+            deleted = cache_result["deleted_rows"] + query_result["deleted_rows"]
+            if deleted > 0 or cache_result["vacuumed"] or query_result["vacuumed"]:
+                logger.info(
+                    "SQLite maintenance deleted %s rows "
+                    "(expired_content_cache=%s, old_fetch_logs=%s, old_query_logs=%s, vacuumed=%s)",
+                    deleted,
+                    cache_result["expired_content_cache"],
+                    cache_result["old_fetch_logs"],
+                    query_result["old_query_logs"],
+                    cache_result["vacuumed"] or query_result["vacuumed"],
+                )
+        except Exception as exc:
+            logger.debug("SQLite maintenance failed: %s", exc)
+        finally:
+            maintenance_lock.release()
+
+    # Periodic SQLite maintenance: cache expiry, log retention, and optimize.
+    async def _maintenance_loop():
+        while True:
+            await asyncio.sleep(SQLITE_MAINTENANCE_INTERVAL_SECONDS)
+            threading.Thread(
+                target=_run_sqlite_maintenance,
+                name="agentsearch-sqlite-maintenance",
+                daemon=True,
+            ).start()
+
+    maintenance_task = asyncio.create_task(_maintenance_loop())
 
     yield
 
-    evict_task.cancel()
+    maintenance_task.cancel()
     if created_http_client and hasattr(http_client, "aclose"):
         await http_client.aclose()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 import asyncio
 import os
 import socket
+import sqlite3
 import sys
+import time
 import types
 
 import httpx
@@ -21,6 +23,7 @@ from app import killchain
 from app import main
 from app import browser_renderer
 from app.cache import Cache
+from app.content_cache import ContentCache
 from app.database import QueryDatabase
 from app.dedup import deduplicate_with_scoring
 from adapters import medium as medium_adapter
@@ -1039,6 +1042,94 @@ def test_query_database_async_methods_use_bounded_sqlite(tmp_path) -> None:
     assert stats["total_queries"] == 1
     assert stats["queries_per_engine"] == {"brave": 1, "duckduckgo": 1}
     assert stats["avg_results_per_engine"] == {"brave": 2.0, "duckduckgo": 2.0}
+
+
+def test_content_cache_maintenance_prunes_expired_cache_and_old_fetch_logs(tmp_path) -> None:
+    cache_db = ContentCache(str(tmp_path / "content_cache.db"))
+    now = time.time()
+    old = now - 31 * 86400
+    fresh = now - 5
+
+    with sqlite3.connect(cache_db.db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO content_cache
+            (url_hash, url, content, strategy, chars, created_at, expires_at)
+            VALUES ('expired', 'https://example.com/old', 'old', 'direct', 3, ?, ?)
+            """,
+            (old, old),
+        )
+        conn.execute(
+            """
+            INSERT INTO content_cache
+            (url_hash, url, content, strategy, chars, created_at, expires_at)
+            VALUES ('fresh', 'https://example.com/new', 'new', 'direct', 3, ?, ?)
+            """,
+            (fresh, now + 3600),
+        )
+        conn.execute(
+            """
+            INSERT INTO fetch_log
+            (url, domain, strategy, success, chars, strategies_tried, error, timestamp)
+            VALUES ('https://example.com/old-log', 'example.com', 'direct', 1, 3, 'direct', NULL, ?)
+            """,
+            (old,),
+        )
+        conn.execute(
+            """
+            INSERT INTO fetch_log
+            (url, domain, strategy, success, chars, strategies_tried, error, timestamp)
+            VALUES ('https://example.com/new-log', 'example.com', 'direct', 1, 3, 'direct', NULL, ?)
+            """,
+            (fresh,),
+        )
+        conn.commit()
+
+    result = cache_db.maintain(fetch_log_retention_days=30, vacuum_min_deleted_rows=1)
+
+    with sqlite3.connect(cache_db.db_path) as conn:
+        cache_count = conn.execute("SELECT COUNT(*) FROM content_cache").fetchone()[0]
+        fetch_count = conn.execute("SELECT COUNT(*) FROM fetch_log").fetchone()[0]
+
+    assert result["expired_content_cache"] == 1
+    assert result["old_fetch_logs"] == 1
+    assert result["deleted_rows"] == 2
+    assert result["vacuumed"] is True
+    assert cache_count == 1
+    assert fetch_count == 1
+
+
+def test_query_database_maintenance_prunes_old_query_logs(tmp_path) -> None:
+    db = QueryDatabase(str(tmp_path / "query_log.db"))
+    now = time.time()
+    old = now - 31 * 86400
+    fresh = now - 5
+
+    with sqlite3.connect(db.db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO query_log (query, timestamp, engine, result_count, response_time_ms)
+            VALUES ('old query', ?, 'bing', 1, 10.0)
+            """,
+            (old,),
+        )
+        conn.execute(
+            """
+            INSERT INTO query_log (query, timestamp, engine, result_count, response_time_ms)
+            VALUES ('fresh query', ?, 'bing', 2, 20.0)
+            """,
+            (fresh,),
+        )
+        conn.commit()
+
+    result = db.maintain(query_log_retention_days=30, vacuum_min_deleted_rows=1)
+    stats = asyncio.run(db.get_stats())
+
+    assert result["old_query_logs"] == 1
+    assert result["deleted_rows"] == 1
+    assert result["vacuumed"] is True
+    assert stats["total_queries"] == 1
+    assert stats["queries_per_engine"] == {"bing": 1}
 
 
 def test_empty_query_returns_400(client: AppClient) -> None:


### PR DESCRIPTION
## What changed

Adds scheduled SQLite maintenance for AgentSearch persistent state:

- deletes expired `content_cache` rows
- deletes `fetch_log` rows older than `FETCH_LOG_RETENTION_DAYS` (default 30)
- deletes `query_log` rows older than `QUERY_LOG_RETENTION_DAYS` (default 30)
- runs `PRAGMA optimize`
- runs `VACUUM` only when deleted rows meet `SQLITE_VACUUM_MIN_DELETED_ROWS` (default 1000; 0 disables threshold vacuum)
- documents the new configuration knobs

## Validation

- `python3 -m pytest -q` -> `62 passed, 10 skipped`
- `python3 -m compileall app adapters mcp-server/agent_search_mcp scripts sdk -q`
- `git diff --check`
