### PR TITLE
feat: add SerpBase (Google) search provider

### DIFF
--- a/app/search_providers.py
+++ b/app/search_providers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import time
 import xml.etree.ElementTree as ET
@@ -565,6 +566,39 @@ class SemanticScholarProvider(SearchProvider):
         return results
 
 
+class SerpBaseProvider(SearchProvider):
+    name = "serpbase"
+    engine_name = "serpbase (Google)"
+
+    async def _search(self, client: httpx.AsyncClient, query: str, count: int) -> list[dict]:
+        api_key = os.environ.get("SERPBASE_API_KEY", "").strip()
+        if not api_key:
+            return []
+        resp = await client.get(
+            "https://api.serpbase.dev/google/search",
+            params={"q": query, "num": min(max(count, 1), 100), "api_key": api_key},
+            headers=DEFAULT_PROVIDER_HEADERS,
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        organic = data.get("organic_results", [])
+        if not isinstance(organic, list):
+            return []
+        results: list[dict] = []
+        for item in organic:
+            if not isinstance(item, dict):
+                continue
+            results.append(self._result(
+                item.get("title"),
+                item.get("link"),
+                item.get("snippet") or "",
+            ))
+            if len(results) >= count * 3:
+                break
+        return results
+
+
 PROVIDERS: dict[str, SearchProvider] = {
     "mdn": MDNProvider(),
     "github": GitHubProvider(),
@@ -578,4 +612,5 @@ PROVIDERS: dict[str, SearchProvider] = {
     "crossref": CrossrefProvider(),
     "openalex": OpenAlexProvider(),
     "semantic_scholar": SemanticScholarProvider(),
+    "serpbase": SerpBaseProvider(),
 }


### PR DESCRIPTION
## Summary
Add SerpBase as an optional web search provider — returns Google search results via REST API with zero scraping maintenance.

## Background
AgentSearch currently offers 12 direct providers (MDN, GitHub, PyPI, Wikipedia, etc.) but none provide general web search. For research queries where niche sources don't have the answer, a Google web search provider fills the gap. SerpBase returns structured organic results (title, link, snippet) in JSON — a clean fit for the existing SearchProvider interface.

## Changes
- **New**: `SerpBaseProvider` class in `app/search_providers.py` — REST API-based Google search provider
- **Updated**: `PROVIDERS` dict — registered as `"serpbase"`
- **Updated**: `import os` added for environment variable access

No new dependencies — uses the existing `httpx` library already in the project.

## Design decisions
| Decision | Rationale |
|----------|----------|
| API key via `SERPBASE_API_KEY` env var | Follows common convention; avoids hardcoding credentials |
| Graceful skip when key missing | Returns `[]` instead of raising — other providers continue unaffected |
| Named `"serpbase"` in catalog | Clear, unique, matches the product name |
| Uses `DEFAULT_PROVIDER_HEADERS` | Consistent with all other providers |

## Testing
- When `SERPBASE_API_KEY` is set: returns Google search results via `GET https://api.serpbase.dev/google/search`
- When unset: returns `[]`, no error raised
- Existing providers and tests unaffected (no signature changes)

## Related
- SerpBase offers 100 free searches (no credit card) at https://serpbase.dev
- API docs: https://serpbase.dev/docs