### PR TITLE
Docs: point to lighter-weight siblings (scholar, agent-read, agent-web)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ SearXNG finds pages. AgentSearch fetches and reads them, scores and deduplicates
 | **Adaptive (failure analysis)** | ✅ (evolver) | ❌ | ❌ | ❌ | ❌ |
 | **Tor anonymization** | Optional | ❌ | ❌ | ❌ | Manual |
 
+## Lighter-weight siblings
+
+AgentSearch is the full self-hosted stack. If you only need one slice of it —
+keyless, no server, `pip`/`uv`-installable — these carve a single job out of it
+and do just that one thing:
+
+- **[scholar](https://github.com/brcrusoe72/scholar-cli)** — scholarly search over OpenAlex: peer-reviewed sources and citation graphs, where credibility is data (venue, citations, retraction flags) rather than vibes. *(52% primary-source precision on a 20-question benchmark.)*
+- **[agent-read](https://github.com/brcrusoe72/agent-read)** — this repo's extraction chain as a standalone `URL → clean text` CLI: the same escalation (direct → readability → UA-rotation → Wayback → PDF), no Docker, no SearXNG. *(85% usable text on 40 hard URLs, vs. 48% for a naive fetch.)*
+- **[agent-web](https://github.com/brcrusoe72/agent-web)** — for pages that need *interaction* rather than a fetch: drive a real browser and act on a compact accessibility snapshot with element refs. *(Snapshot ≈ 16× smaller than raw HTML.)*
+
 ## Endpoints
 
 ### Search


### PR DESCRIPTION
Adds a "Lighter-weight siblings" section to the README, after the *Why not just use SearXNG directly?* comparison.

AgentSearch is the full self-hosted stack. These three carve one job out of it and do just that, keyless and server-less:

- **scholar** — scholarly search over OpenAlex (52% primary-source precision, 20-question benchmark).
- **agent-read** — this repo's extraction chain as a standalone URL→clean-text CLI (85% usable text on 40 hard URLs vs. 48% for a naive fetch).
- **agent-web** — browser interaction via accessibility snapshot + refs (snapshot ≈16× smaller than raw HTML).

Docs-only change; no code touched.