### PR TITLE
feat: add optional You.com search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Run `./scripts/prepare-searxng.sh` to create ignored local runtime files at `sea
 
 Because SearXNG is configured with `use_default_settings: true`, your live instance may expose additional enabled engines from the installed SearXNG catalog. Use the `engines=` query parameter to request specific engines, and use `/engines` to verify what is available in that deployment.
 
-Strategy modes can also use direct no-key providers for vertical search. These do not require paid search APIs: GitHub repository search, MDN search, Docker Hub search, PyPI package metadata, Wikipedia, Wikidata, Hacker News, arXiv, Crossref, OpenAlex, and Semantic Scholar are called directly when a mode selects them. SearXNG remains the broad-web provider for Google/Bing/Brave/DuckDuckGo-style engines, but Google, Startpage, Yahoo, and Reddit are best-effort explicit sources rather than defaults because they are commonly blocked or empty.
+Strategy modes can also use direct no-key providers for vertical search. These do not require paid search APIs: GitHub repository search, MDN search, Docker Hub search, PyPI package metadata, You.com Search (`YDC_API_KEY` optional), Wikipedia, Wikidata, Hacker News, arXiv, Crossref, OpenAlex, and Semantic Scholar are called directly when a mode selects them. SearXNG remains the broad-web provider for Google/Bing/Brave/DuckDuckGo-style engines, but Google, Startpage, Yahoo, and Reddit are best-effort explicit sources rather than defaults because they are commonly blocked or empty.
 
 ## Why not just use SearXNG directly?
 

--- a/app/main.py
+++ b/app/main.py
@@ -333,6 +333,7 @@ SEARCH_STRATEGY_MODES: dict[str, tuple[SearchStrategyPack, ...]] = {
     "general": (
         _searxng_pack("bing"),
         _searxng_pack("duckduckgo", "brave"),
+        _provider_pack("youcom", "youcom"),
         _provider_pack("wikipedia", "wikipedia"),
         _provider_pack("wikidata", "wikidata"),
         _provider_pack("hackernews", "hackernews"),

--- a/app/search_providers.py
+++ b/app/search_providers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import time
 import xml.etree.ElementTree as ET
@@ -565,6 +566,54 @@ class SemanticScholarProvider(SearchProvider):
         return results
 
 
+class YouComProvider(SearchProvider):
+    name = "youcom"
+    engine_name = "you.com"
+
+    def _headers(self) -> dict[str, str]:
+        headers = dict(DEFAULT_PROVIDER_HEADERS)
+        api_key = os.getenv("YDC_API_KEY", "").strip()
+        if api_key:
+            headers["X-API-Key"] = api_key
+        return headers
+
+    async def _search(self, client: httpx.AsyncClient, query: str, count: int) -> list[dict]:
+        resp = await client.get(
+            "https://api.you.com/v1/agents/search",
+            params={
+                "query": query,
+                "count": min(max(count * 3, 1), 50),
+            },
+            headers=self._headers(),
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        results: list[dict] = []
+
+        for section_name in ("web", "news"):
+            section_items = _json_items(data, "results", section_name)
+            if not isinstance(section_items, list):
+                continue
+            for item in section_items[: count * 3]:
+                if not isinstance(item, dict):
+                    continue
+                url = _safe_text(item.get("url"))
+                if not url:
+                    continue
+                title = item.get("title") or url
+                snippet = item.get("description") or item.get("snippet") or item.get("content") or ""
+                if section_name == "news":
+                    page_age = _safe_text(item.get("page_age"))
+                    if page_age:
+                        snippet = f"{snippet} Published: {page_age}".strip()
+                results.append(self._result(title, url, snippet))
+                if len(results) >= count * 3:
+                    return results
+
+        return results
+
+
 PROVIDERS: dict[str, SearchProvider] = {
     "mdn": MDNProvider(),
     "github": GitHubProvider(),
@@ -578,4 +627,5 @@ PROVIDERS: dict[str, SearchProvider] = {
     "crossref": CrossrefProvider(),
     "openalex": OpenAlexProvider(),
     "semantic_scholar": SemanticScholarProvider(),
+    "youcom": YouComProvider(),
 }

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -79,7 +79,7 @@ curl "http://localhost:3939/engines"
 
 The bundled AgentSearch SearXNG config explicitly enables a focused engine set, and `use_default_settings: true` can expose additional engines from the installed SearXNG catalog. Avoid hard-coding a fixed engine count in clients.
 
-Strategy modes also include direct no-key providers for GitHub, MDN, Docker Hub, PyPI, Wikipedia, Wikidata, Hacker News, arXiv, Crossref, OpenAlex, and Semantic Scholar. Reddit is treated as best-effort because anonymous requests are often blocked. Use `providers_health` and `providers_stats` to inspect which providers are actually returning rows in the current process.
+Strategy modes also include direct no-key providers for GitHub, MDN, Docker Hub, PyPI, You.com Search (`YDC_API_KEY` optional), Wikipedia, Wikidata, Hacker News, arXiv, Crossref, OpenAlex, and Semantic Scholar. Reddit is treated as best-effort because anonymous requests are often blocked. Use `providers_health` and `providers_stats` to inspect which providers are actually returning rows in the current process.
 
 ## Connect from Claude Desktop
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,6 +26,7 @@ from app.cache import Cache
 from app.content_cache import ContentCache
 from app.database import QueryDatabase
 from app.dedup import deduplicate_with_scoring
+from app.search_providers import provider_by_name, providers_catalog
 from adapters import medium as medium_adapter
 from adapters.safe_fetch import safe_requests_get
 
@@ -153,6 +154,7 @@ class EngineAwareFakeSearxngClient:
         self.crossref_params: list[dict] = []
         self.openalex_params: list[dict] = []
         self.semantic_scholar_params: list[dict] = []
+        self.youcom_params: list[dict] = []
 
     async def get(self, url: str, params: dict | None = None, timeout: float | None = None, **kwargs) -> FakeResponse:
         url = str(url)
@@ -303,6 +305,41 @@ class EngineAwareFakeSearxngClient:
                     }
                 ]
             })
+        if url.startswith("https://api.you.com/v1/agents/search"):
+            request_headers = dict(kwargs.get("headers") or {})
+            self.youcom_params.append({
+                "params": dict(params or {}),
+                "headers": request_headers,
+            })
+            return FakeResponse({
+                "results": {
+                    "web": [
+                        {
+                            "title": "You.com web result",
+                            "url": "https://example.com/youcom-web",
+                            "description": "You.com web snippet",
+                        },
+                        {
+                            "title": "You.com second web result",
+                            "url": "https://example.org/youcom-web-2",
+                            "description": "You.com web snippet two",
+                        },
+                    ],
+                    "news": [
+                        {
+                            "title": "You.com news result",
+                            "url": "https://news.example.com/youcom-news",
+                            "description": "You.com news snippet",
+                            "page_age": "2026-07-22T00:00:00",
+                        }
+                    ],
+                },
+                "metadata": {
+                    "query": (params or {}).get("query", ""),
+                    "search_uuid": "test-search-uuid",
+                    "latency": 0.12,
+                },
+            })
         if url.endswith("/config"):
             return FakeResponse({
                 "engines": [
@@ -329,7 +366,10 @@ class EngineAwareFakeSearxngClient:
             search_params = params or {}
             self.search_params.append(dict(search_params))
             engine = search_params.get("engines")
-            if engine == "bing" and "fallback" in search_params.get("q", ""):
+            query_text = search_params.get("q", "")
+            if engine == "bing" and "fallback" in query_text:
+                return FakeResponse({"results": []})
+            if engine == "duckduckgo,brave" and "youcom" in query_text:
                 return FakeResponse({"results": []})
 
             engine_names = [item.strip() for item in (engine or "bing").split(",") if item.strip()]
@@ -690,6 +730,7 @@ def test_provider_stats_and_health_record_direct_attempts(monkeypatch: pytest.Mo
         (row["source"], row["name"]): row
         for row in stats.json()["providers"]
     }
+    assert "youcom" in {item["name"] for item in stats.json()["known_direct_providers"]}
     for name in ["github", "mdn", "docker_hub", "pypi"]:
         row = providers[("provider", name)]
         assert row["attempts"] == 1
@@ -701,6 +742,42 @@ def test_provider_stats_and_health_record_direct_attempts(monkeypatch: pytest.Mo
     data = health.json()
     assert data["status"] == "healthy"
     assert data["attempted"] >= 4
+
+
+def test_youcom_provider_uses_optional_api_key_and_maps_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("YDC_API_KEY", "ydc-test-key")
+    fake = EngineAwareFakeSearxngClient()
+
+    async def run_provider():
+        provider = provider_by_name("youcom")
+        return await provider.search(fake, "agentic search", 2)
+
+    result = asyncio.run(run_provider())
+
+    assert fake.youcom_params[0]["params"]["query"] == "agentic search"
+    assert fake.youcom_params[0]["params"]["count"] == 6
+    assert fake.youcom_params[0]["headers"]["X-API-Key"] == "ydc-test-key"
+    assert result.provider == "youcom"
+    assert [item["url"] for item in result.results] == [
+        "https://example.com/youcom-web",
+        "https://example.org/youcom-web-2",
+        "https://news.example.com/youcom-news",
+    ]
+    assert "Published: 2026-07-22T00:00:00" in result.results[2]["content"]
+
+
+def test_search_strategy_general_uses_youcom_provider_when_searxng_needs_more_coverage(monkeypatch: pytest.MonkeyPatch, client: AppClient) -> None:
+    monkeypatch.setenv("YDC_API_KEY", "ydc-test-key")
+    fake = EngineAwareFakeSearxngClient()
+    monkeypatch.setattr(main, "http_client", fake)
+
+    response = client.get("/search", params={"q": "youcom fallback", "count": 1, "mode": "general"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert any(attempt["provider"] == "youcom" for attempt in data["meta"]["engine_attempts"])
+    assert fake.youcom_params[0]["headers"]["X-API-Key"] == "ydc-test-key"
+    assert data["results"][0]["url"] == "https://example.com/youcom-web"
 
 
 def test_search_records_searxng_error_attempt(monkeypatch: pytest.MonkeyPatch, client: AppClient) -> None:


### PR DESCRIPTION
This adds an optional You.com Search provider to the existing strategy-mode search pipeline.

Why this is useful for this project:
- It gives AgentSearch one more broad-web backend without changing the default SearXNG path.
- The provider fits the existing direct-provider registry, so it stays small and opt-in.
- You.com can supply an extra result source when the current engines do not have enough coverage.

What changed:
- Added a `youcom` provider in `app/search_providers.py` that calls the You.com Search API.
- Registered `youcom` in the provider catalog so it shows up in provider stats/health.
- Added `youcom` to the general strategy pack in `app/main.py`.
- Documented the new provider in the API README and MCP README.
- Added tests for provider mapping, optional `YDC_API_KEY` handling, and general-strategy fallback.

Setup / env vars:
- `YDC_API_KEY` is optional.
- When present, it is sent as `X-API-Key` to You.com.
- Existing behavior is unchanged when the env var is absent.

Usage example:
- `GET /search?q=agentic+search&mode=general`
- If Bing and the other SearXNG packs do not return enough coverage, the strategy can fall through to `youcom`.

Validation performed:
- `uv run -q pytest tests/test_api.py tests/test_sdk_client.py`
- Result: 49 passed, 1 skipped

Fallback / error handling:
- The provider is only reached through the existing strategy flow.
- Missing `YDC_API_KEY` does not disable the provider.
- Existing SearXNG-backed behavior is unchanged.

Tracking issue: https://github.com/youdotcom-oss/integration-tracking/issues/108
