### PR TITLE
Pin SearXNG to 2026.9.5 so default search keeps Brave and DuckDuckGo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Do not commit real tokens or machine-specific secrets.
 
 SEARXNG_URL=http://localhost:8080
-SEARXNG_IMAGE=searxng/searxng@sha256:4d7ed8b7035ecf827bd901ba6d32f5c32d8119bc09bb3cdafeb0ce58f1b951c1
+SEARXNG_IMAGE=searxng/searxng@sha256:55e1fa15a63ff04e79e213e6aa2837549877b0c6d60757cdb633ae9111cb5fea
 PYTHON_BASE_IMAGE=python@sha256:9e01bf1ae5db7649a236da7be1e94ffbbbdd7a93f867dd0d8d5720d9e1f89fab
 COREDNS_IMAGE=coredns/coredns@sha256:b21d26b915e10acb5bc78715c1e8b6047ab2675389b2bcc18b3a6499d90e74c0
 SOCAT_IMAGE=alpine/socat@sha256:44e7b87dfeddb0f999ce75eedfa140dc97ea5bf7decbd04b2cef6adb5cc331fe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ release. Use semantic version tags such as `v2.0.1`.
 
 ## Unreleased
 
+- Pinned SearXNG to 2026.9.5 (sha256:55e1fa15a63ff04e79e213e6aa2837549877b0c6d60757cdb633ae9111cb5fea) so Brave, DuckDuckGo, and Google remain usable on default search; the March 2026 pin left those engines unresponsive and default results collapsed onto Bing.
 - Added production GitHub governance: CodeQL, Dependabot, release workflow, and branch protection readiness.
 - Added runtime hardening: pinned container images, generated SearXNG runtime secrets, constant-time bearer auth comparison, and optional live Docker smoke tests.
 - Added CI hardening for tests, package builds, Compose validation, and API/MCP/Tor Docker builds.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ AgentSearch delegates engine support to the connected SearXNG instance. The auth
 curl "http://localhost:3939/engines"
 ```
 
-The bundled `searxng/settings.example.yml` explicitly enables 25 engines, including best-effort Google/Startpage/Yahoo entries plus Brave, Bing, DuckDuckGo, Google Scholar, Semantic Scholar, arXiv, Crossref, OpenAlex, PubMed, Bing News, Reuters, Wikinews, Wikipedia, Wikidata, Hugging Face, Reddit, Hacker News, Stack Overflow, GitHub, Docker Hub, and Lobsters.
+The bundled `searxng/settings.example.yml` explicitly enables 25 engines, including best-effort Google/Startpage/Yahoo entries plus Brave, Bing, DuckDuckGo, Google Scholar, Semantic Scholar, arXiv, Crossref, OpenAlex, PubMed, Bing News, Reuters, Wikinews, Wikipedia, Wikidata, Hugging Face, Reddit, Hacker News, Stack Overflow, GitHub, Docker Hub, and Lobsters. The default Compose pin is SearXNG 2026.9.5 (searxng/searxng@sha256:55e1fa15a63ff04e79e213e6aa2837549877b0c6d60757cdb633ae9111cb5fea). Re-pin only after comparing live engines on a throwaway container: the previous 2026.3.29 pin left Brave, DuckDuckGo, and Google unresponsive, so default /search collapsed onto Bing junk. Upstream Bing issue searxng/searxng#4964 remains open.
 
 Run `./scripts/prepare-searxng.sh` to create ignored local runtime files at `searxng/settings.yml` and `searxng/settings.tor.yml` with generated SearXNG instance secrets. Do not commit those generated files.
 
@@ -401,7 +401,7 @@ Environment variables (set in `docker-compose.yml` or `.env`):
 | Variable | Default | Description |
 |---|---|---|
 | `SEARXNG_URL` | `http://searxng:8080` | SearXNG instance URL |
-| `SEARXNG_IMAGE` | pinned SearXNG digest | SearXNG container image; override only when intentionally upgrading |
+| `SEARXNG_IMAGE` | pinned SearXNG digest (2026.9.5) | SearXNG container image; override only after a live engine comparison on the candidate |
 | `PYTHON_BASE_IMAGE` | pinned Python digest | API Docker base image; override only when intentionally upgrading |
 | `COREDNS_IMAGE` | pinned CoreDNS digest | Private-stack DNS image |
 | `SOCAT_IMAGE` | pinned socat digest | Private-stack TCP forwarder image |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   searxng:
-    image: ${SEARXNG_IMAGE:-searxng/searxng@sha256:4d7ed8b7035ecf827bd901ba6d32f5c32d8119bc09bb3cdafeb0ce58f1b951c1}
+    image: ${SEARXNG_IMAGE:-searxng/searxng@sha256:55e1fa15a63ff04e79e213e6aa2837549877b0c6d60757cdb633ae9111cb5fea}
     container_name: agent-search-searxng
     volumes:
       - ./searxng:/etc/searxng:rw

--- a/examples/compose.private.yml
+++ b/examples/compose.private.yml
@@ -58,7 +58,7 @@ services:
 
   # === Private SearXNG — all traffic through Tor ===
   searxng-private:
-    image: ${SEARXNG_IMAGE:-searxng/searxng@sha256:4d7ed8b7035ecf827bd901ba6d32f5c32d8119bc09bb3cdafeb0ce58f1b951c1}
+    image: ${SEARXNG_IMAGE:-searxng/searxng@sha256:55e1fa15a63ff04e79e213e6aa2837549877b0c6d60757cdb633ae9111cb5fea}
     container_name: agent-search-searxng-private
     volumes:
       - ./searxng:/etc/searxng:rw


### PR DESCRIPTION
The March 2026 SearXNG pin left Brave, DuckDuckGo, and Google unresponsive, so ordinary `/search` collapsed onto Bing junk ([searxng/searxng#4964](https://github.com/searxng/searxng/issues/4964) remains open).

This re-pins the default Compose image to SearXNG 2026.9.5 (`sha256:55e1fa15a63ff04e79e213e6aa2837549877b0c6d60757cdb633ae9111cb5fea`) after a live engine comparison on a throwaway container. Runtime `settings.yml` is unchanged. Re-pin later only after comparing live engines on a candidate image.

No search-strategy code changes.